### PR TITLE
fix: correct transport type key in server.json

### DIFF
--- a/server.json
+++ b/server.json
@@ -20,7 +20,7 @@
   ],
   "remotes": [
     {
-      "transport_type": "streamable-http",
+      "type": "streamable-http",
       "url": "https://mcp.elnora.ai/mcp"
     }
   ]


### PR DESCRIPTION
## Summary
- Fix `transport_type` → `type` in server.json remotes array per MCP Registry schema

## Context
The MCP Registry schema requires `type` not `transport_type` for remote transport definitions. This was caught during registry submission validation.

## Test plan
- [x] CI passes
- [x] server.json validates against registry schema

🤖 Generated with [Claude Code](https://claude.com/claude-code)