### PR TITLE
fix(docs): correct MCP transport type in setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Add the Elnora MCP server to your AI client. No installation required — just p
 ### Claude Code
 
 ```bash
-claude mcp add elnora --transport streamable-http https://mcp.elnora.ai/mcp
+claude mcp add elnora --transport http https://mcp.elnora.ai/mcp
 ```
 
 ### Cursor
@@ -40,7 +40,7 @@ Add to your `.vscode/mcp.json`:
 {
   "servers": {
     "elnora": {
-      "type": "streamable-http",
+      "type": "http",
       "url": "https://mcp.elnora.ai/mcp"
     }
   }


### PR DESCRIPTION
## Summary

- Fix Claude Code instruction: `--transport streamable-http` → `--transport http`
- Fix VS Code instruction: `"type": "streamable-http"` → `"type": "http"`

Both Claude Code and VS Code use `http` as the transport type name. The MCP spec name `streamable-http` is only used in server registry manifests (`server.json`), not in client configs.

Discovered while testing installation in Claude Code — the CLI rejected `streamable-http` with: `Invalid transport type: streamable-http. Must be one of: stdio, sse, http`.

**Other client instructions verified:**
- **Cursor** — correct (uses URL only, no transport type)
- **Codex** — correct (uses URL only)
- **ChatGPT** — correct (URL-based setup)

## Test plan

- [x] Verify `claude mcp add elnora --transport http https://mcp.elnora.ai/mcp` works in Claude Code
- [x] Verify VS Code `.vscode/mcp.json` with `"type": "http"` connects successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)