### PR TITLE
fix: default HOST to 0.0.0.0 for ECS compatibility

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,8 +20,8 @@ ELNORA_PLATFORM_CLIENT_SECRET=your-client-secret-here
 # Optional — Server port (default: 3000)
 PORT=3000
 
-# Optional — Bind host (default: 127.0.0.1)
-HOST=127.0.0.1
+# Optional — Bind host (default: 0.0.0.0)
+HOST=0.0.0.0
 
 # Optional — Additional CORS origins (comma-separated)
 # CORS_ALLOWED_ORIGINS=https://app.example.com,https://staging.example.com

--- a/src/index.ts
+++ b/src/index.ts
@@ -279,7 +279,7 @@ async function main(): Promise<void> {
     res.status(405).json({ error: "method_not_allowed", error_description: "Stateless server — sessions not supported" });
   });
 
-  const host = process.env.HOST || "127.0.0.1";
+  const host = process.env.HOST || "0.0.0.0";
   const httpServer = app.listen(config.port, host, () => {
     console.error(`Elnora MCP server running on http://${host}:${config.port}/mcp`);
     console.error(`OAuth AS Metadata: ${config.publicUrl}/.well-known/oauth-authorization-server`);


### PR DESCRIPTION
## Summary
- Default `HOST` changed from `127.0.0.1` to `0.0.0.0` so the container accepts connections from the ECS load balancer
- v0.4.0 introduced explicit host binding which broke ECS health checks (caused deploy stabilization failure)

## Test plan
- [ ] Merge → release-please bumps to v0.4.1 → deploy triggers → ECS stabilizes

🤖 Generated with [Claude Code](https://claude.com/claude-code)