### PR TITLE
fix: use ipKeyGenerator for IPv6 rate-limit warning

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,7 @@ import { createElnoraServer } from "./server.js";
 import { corsMiddleware } from "./middleware/cors.js";
 import { SUPPORTED_SCOPES, ALL_SCOPES } from "./constants.js";
 import { logAuthEvent } from "./middleware/tool-logging.js";
-import rateLimit from "express-rate-limit";
+import rateLimit, { ipKeyGenerator } from "express-rate-limit";
 import axios from "axios";
 
 function requireEnv(name: string): string {
@@ -163,7 +163,7 @@ async function main(): Promise<void> {
       const apiKeyHeader = req.headers["x-api-key"];
       if (authHeader) return `auth:${authHeader.slice(-16)}`;
       if (apiKeyHeader) return `key:${String(apiKeyHeader).slice(-8)}`;
-      return `ip:${req.ip || req.socket.remoteAddress || "unknown"}`;
+      return `ip:${ipKeyGenerator(req.ip || req.socket.remoteAddress || "unknown")}`;
     },
     message: { error: "rate_limit_exceeded", error_description: "Too many requests. Please retry later." },
   }));


### PR DESCRIPTION
## Summary
- Import and use `ipKeyGenerator` from `express-rate-limit` for the IP fallback in the custom `keyGenerator`
- Resolves `ERR_ERL_KEY_GEN_IPV6` validation warning logged on every startup
- Also properly handles IPv6 subnet masking to prevent rate-limit bypass via IP rotation

## Test plan
- [ ] Deploy and verify no `ValidationError` in CloudWatch logs on startup

🤖 Generated with [Claude Code](https://claude.com/claude-code)