### PR TITLE
docs: streamline README with compact capabilities table

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Connect AI agents to the [Elnora](https://elnora.ai) bioprotocol optimization pl
 
 ## What is Elnora?
 
-Elnora is an AI-powered platform that helps researchers generate, optimize, and manage bioprotocols for wet-lab experiments. With this MCP server, you can interact with Elnora directly from AI coding assistants like Claude Code, Codex, Cursor, VS Code, and ChatGPT.
+Elnora is an AI-powered platform that helps researchers generate, optimize, and manage bioprotocols for wet-lab experiments. With this MCP server, you can interact with Elnora directly from AI coding assistants like Claude Code, Cursor, VS Code, Codex, and ChatGPT.
 
 ## Quick Start
 
@@ -25,14 +25,6 @@ claude mcp add elnora --transport http --scope user https://mcp.elnora.ai/mcp
 | User | `--scope user` | `~/.claude.json` | Available in all your projects (recommended) |
 | Local | `--scope local` | Current project config | Single-project use (default if omitted) |
 | Project | `--scope project` | `.mcp.json` in project root | Team sharing via version control |
-
-```bash
-# Personal — available everywhere (recommended)
-claude mcp add elnora --transport http --scope user https://mcp.elnora.ai/mcp
-
-# Project — shared with your team via git
-claude mcp add elnora --transport http --scope project https://mcp.elnora.ai/mcp
-```
 
 ### Cursor
 
@@ -89,159 +81,6 @@ Add as a remote MCP server in ChatGPT settings using the URL `https://mcp.elnora
 
 On first connection, a browser window will open for OAuth login. Subsequent requests use the issued token automatically.
 
-## Available Tools
-
-74 tools across 15 categories. Every tool includes scope-based access control.
-
-### Tasks (6 tools)
-
-| Tool | Description |
-|------|-------------|
-| `elnora_create_task` | Create a new task (conversation thread) with optional initial message and context files |
-| `elnora_list_tasks` | List tasks with optional project and status filters |
-| `elnora_get_task` | Get a single task by UUID |
-| `elnora_get_task_messages` | Get paginated message history for a task |
-| `elnora_update_task` | Update task title or status |
-| `elnora_archive_task` | Archive (delete) a task |
-
-### Messages (1 tool)
-
-| Tool | Description |
-|------|-------------|
-| `elnora_send_message` | Send a message to a task and receive the AI response (30-120s for complex requests) |
-
-### Files (18 tools)
-
-| Tool | Description |
-|------|-------------|
-| `elnora_list_files` | List files in a project or workspace |
-| `elnora_get_file` | Get file metadata by UUID |
-| `elnora_get_file_content` | Retrieve file content |
-| `elnora_get_file_versions` | Get version history for a file |
-| `elnora_get_version_content` | Get content of a specific file version |
-| `elnora_upload_file` | Upload a text file |
-| `elnora_create_file` | Create a new empty file in a project |
-| `elnora_update_file` | Update file metadata (rename or move) |
-| `elnora_archive_file` | Archive (delete) a file |
-| `elnora_download_file` | Download a file (returns download URL or content) |
-| `elnora_create_version` | Create a new version of a file |
-| `elnora_restore_version` | Restore a file to a specific version |
-| `elnora_promote_file` | Promote file visibility (e.g., to organization library) |
-| `elnora_fork_file` | Fork a file to another project |
-| `elnora_create_working_copy` | Create a working copy for editing |
-| `elnora_commit_working_copy` | Commit a working copy back to the file |
-| `elnora_initiate_upload` | Initiate a multi-step upload (returns presigned URL) |
-| `elnora_confirm_upload` | Confirm that a presigned upload has completed |
-
-### Protocols (1 tool)
-
-| Tool | Description |
-|------|-------------|
-| `elnora_generate_protocol` | Generate a bioprotocol — creates a task, sends your description, and returns the result (30-120s) |
-
-### Projects (10 tools)
-
-| Tool | Description |
-|------|-------------|
-| `elnora_list_projects` | List all projects |
-| `elnora_get_project` | Get a single project by UUID |
-| `elnora_create_project` | Create a new project |
-| `elnora_update_project` | Update project metadata |
-| `elnora_archive_project` | Archive (soft-delete) a project |
-| `elnora_list_project_members` | List members of a project |
-| `elnora_add_project_member` | Add a user to a project |
-| `elnora_update_project_member_role` | Change a project member's role |
-| `elnora_remove_project_member` | Remove a user from a project |
-| `elnora_leave_project` | Leave a project you are a member of |
-
-### Organizations (13 tools)
-
-| Tool | Description |
-|------|-------------|
-| `elnora_list_orgs` | List organizations you belong to |
-| `elnora_get_org` | Get organization details |
-| `elnora_create_org` | Create a new organization |
-| `elnora_update_org` | Update organization metadata |
-| `elnora_list_org_members` | List organization members |
-| `elnora_update_org_member_role` | Change a member's role |
-| `elnora_remove_org_member` | Remove a member |
-| `elnora_get_org_billing` | Get billing status |
-| `elnora_invite_org_member` | Send an invitation to join |
-| `elnora_list_org_invitations` | List pending invitations |
-| `elnora_cancel_org_invitation` | Cancel a pending invitation |
-| `elnora_get_invitation_info` | Get invitation details by token (no auth required) |
-| `elnora_accept_invitation` | Accept an organization invitation |
-
-### Folders (5 tools)
-
-| Tool | Description |
-|------|-------------|
-| `elnora_list_folders` | List folders in a project |
-| `elnora_create_folder` | Create a folder (supports nesting) |
-| `elnora_rename_folder` | Rename a folder |
-| `elnora_move_folder` | Move a folder to a new parent |
-| `elnora_delete_folder` | Delete a folder |
-
-### Library (5 tools)
-
-| Tool | Description |
-|------|-------------|
-| `elnora_list_library_files` | List files in the organization shared library |
-| `elnora_list_library_folders` | List folders in the shared library |
-| `elnora_create_library_folder` | Create a library folder |
-| `elnora_rename_library_folder` | Rename a library folder |
-| `elnora_delete_library_folder` | Delete a library folder |
-
-### Search (3 tools)
-
-| Tool | Description |
-|------|-------------|
-| `elnora_search_tasks` | Full-text search across tasks |
-| `elnora_search_files` | Full-text search across files |
-| `elnora_search_all` | Full-text search across all resources |
-
-### API Keys (3 tools)
-
-| Tool | Description |
-|------|-------------|
-| `elnora_list_api_keys` | List all personal API keys |
-| `elnora_create_api_key` | Create a new API key |
-| `elnora_revoke_api_key` | Revoke (delete) an API key |
-
-### Audit (1 tool)
-
-| Tool | Description |
-|------|-------------|
-| `elnora_list_audit_log` | List organization audit log entries (filterable by action and user) |
-
-### Account (4 tools)
-
-| Tool | Description |
-|------|-------------|
-| `elnora_get_account` | Get user account details |
-| `elnora_update_account` | Update user account name |
-| `elnora_list_agreements` | List user agreements (terms of service) |
-| `elnora_accept_terms` | Accept a user agreement version |
-
-### Feedback (1 tool)
-
-| Tool | Description |
-|------|-------------|
-| `elnora_submit_feedback` | Submit feedback about the Elnora platform |
-
-### Feature Flags (2 tools)
-
-| Tool | Description |
-|------|-------------|
-| `elnora_list_flags` | List all feature flags (public, no auth required) |
-| `elnora_get_flag` | Get a single feature flag by key |
-
-### Health (1 tool)
-
-| Tool | Description |
-|------|-------------|
-| `elnora_health_check` | Check if the Elnora platform API is reachable |
-
 ## Authentication
 
 ### OAuth 2.1 (Recommended)
@@ -256,7 +95,7 @@ No manual configuration needed.
 
 ### API Key
 
-Alternatively, create an API key in your [Elnora dashboard](https://platform.elnora.ai) and pass it via the `X-API-Key` header:
+Create an API key in your [Elnora dashboard](https://platform.elnora.ai) and pass it via the `X-API-Key` header:
 
 ```json
 {
@@ -277,27 +116,47 @@ Alternatively, create an API key in your [Elnora dashboard](https://platform.eln
 - Rotate keys periodically via the Elnora dashboard
 - Use OAuth when possible — it handles token refresh automatically
 
+## Capabilities
+
+74 tools across 15 categories. All tools are discoverable through your MCP client's tool listing.
+
+| Category | Tools | What you can do |
+|----------|------:|-----------------|
+| Protocols | 1 | Generate optimized bioprotocols from natural language descriptions |
+| Tasks | 6 | Create conversation threads, send messages, get AI responses |
+| Messages | 1 | Chat with Elnora's AI within a task context |
+| Files | 18 | Upload, download, version, fork, and manage protocol files |
+| Projects | 10 | Create projects and manage team membership |
+| Organizations | 13 | Org settings, billing, member invitations |
+| Folders | 5 | Organize files into nested folder structures |
+| Library | 5 | Access the organization's shared protocol library |
+| Search | 3 | Full-text search across tasks, files, and all resources |
+| API Keys | 3 | Create and manage personal API keys |
+| Audit | 1 | Query organization audit logs |
+| Account | 4 | Manage user profile and agreements |
+| Feedback | 1 | Submit platform feedback |
+| Feature Flags | 2 | Check feature availability |
+| Health | 1 | Verify API connectivity |
+
 ## Examples
 
 ### Generate a bioprotocol
 
-Ask your AI assistant:
-
 > "Use Elnora to generate a HEK 293 cell maintenance protocol"
 
-The assistant will call `elnora_generate_protocol` with your description and return the generated protocol.
+The assistant will call `elnora_generate_protocol` with your description and return the generated protocol. This can take 30-120s for complex requests.
 
 ### Search and read files
 
 > "List my files in Elnora, then show me the content of the most recent protocol"
 
-The assistant will call `elnora_list_files` followed by `elnora_get_file_content`.
-
 ### Manage tasks
 
 > "Show me my active Elnora tasks and get the messages from the latest one"
 
-The assistant will call `elnora_list_tasks` and then `elnora_get_task_messages`.
+### Organize a project
+
+> "Create a new project called 'Q3 Assays', add a folder for each cell line, and invite alex@example.com"
 
 ## Troubleshooting
 
@@ -314,20 +173,20 @@ If you encounter persistent issues, please [open a GitHub issue](https://github.
 
 We take security seriously. If you discover a vulnerability, please report it responsibly — see our [security policy](.github/SECURITY.md).
 
-## Changelog
-
-See [CHANGELOG.md](CHANGELOG.md) for version history.
-
 ## Contributing
 
 See [CONTRIBUTING.md](.github/CONTRIBUTING.md) for contribution guidelines.
 
+## Changelog
+
+See [CHANGELOG.md](CHANGELOG.md) for version history.
+
 ## License
 
-This project is licensed under the [Apache License 2.0](LICENSE).
+[Apache License 2.0](LICENSE)
 
 ## Support
 
 - **Bug reports and feature requests:** [GitHub Issues](https://github.com/Elnora-AI/elnora-mcp-server/issues)
-- **Account and billing questions:** [support@elnora.ai](mailto:support@elnora.ai)
+- **Account and billing:** [support@elnora.ai](mailto:support@elnora.ai)
 - **Security vulnerabilities:** [security@elnora.ai](mailto:security@elnora.ai)


### PR DESCRIPTION
## Summary
- Replace detailed per-tool tables (153 lines) with a compact capabilities summary table
- Remove duplicate Claude Code setup code block already shown above the scope table
- Tighten wording throughout (examples, auth section, support footer)
- Add a new "Organize a project" example
- Reorder footer: Contributing before Changelog

## Test plan
- [ ] Verify README renders correctly on GitHub
- [ ] Confirm all links (CHANGELOG, CONTRIBUTING, SECURITY, etc.) still resolve
- [ ] Check capabilities table counts match actual tool count (74 tools, 15 categories)

🤖 Generated with [Claude Code](https://claude.com/claude-code)