### PR TITLE
fix(ci): extract semver from release-please component tags

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,7 +20,10 @@ jobs:
           registry-url: https://registry.npmjs.org
           cache: npm
       - name: Sync version from release tag
-        run: npm version "${GITHUB_REF_NAME#v}" --no-git-tag-version
+        run: |
+          VERSION="${GITHUB_REF_NAME##*-v}"
+          echo "Publishing version: $VERSION"
+          npm version "$VERSION" --no-git-tag-version
       - run: npm ci
       - run: npm run build
       - run: npm test


### PR DESCRIPTION
## Summary
- `${GITHUB_REF_NAME#v}` only strips a leading `v`, but release-please tags as `mcp-server-v0.5.0`
- This resulted in `npm version "mcp-server-0.5.0"` which is invalid semver
- Changed to `${GITHUB_REF_NAME##*-v}` to strip the full component prefix, yielding `0.5.0`

## Test plan
- [ ] Re-trigger the v0.5.0 publish after merge to verify npm publish succeeds

Generated with [Claude Code](https://claude.com/claude-code)