### PR TITLE
fix(ci): allow same version in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,7 +23,7 @@ jobs:
         run: |
           VERSION="${GITHUB_REF_NAME##*-v}"
           echo "Publishing version: $VERSION"
-          npm version "$VERSION" --no-git-tag-version
+          npm version "$VERSION" --no-git-tag-version --allow-same-version
       - run: npm ci
       - run: npm run build
       - run: npm test


### PR DESCRIPTION
release-please already sets version in package.json, so npm version fails with 'Version not changed'. Adds --allow-same-version.