### PR TITLE
fix(auth): add X-Service-Key header and use SDK error types

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,6 +17,9 @@ ELNORA_TOKEN_EXCHANGE_URL=https://platform.elnora.ai/api/v1/auth/token
 ELNORA_PLATFORM_CLIENT_ID=mcp-server
 ELNORA_PLATFORM_CLIENT_SECRET=your-client-secret-here
 
+# Required — Service key for platform token validation endpoint (X-Service-Key header)
+ELNORA_MCP_SERVICE_KEY=your-mcp-service-key-here
+
 # Optional — Server port (default: 3000)
 PORT=3000
 

--- a/src/auth/provider.ts
+++ b/src/auth/provider.ts
@@ -9,6 +9,7 @@ import {
   OAuthTokenRevocationRequest,
 } from "@modelcontextprotocol/sdk/shared/auth.js";
 import { AuthInfo } from "@modelcontextprotocol/sdk/server/auth/types.js";
+import { InvalidTokenError, ServerError } from "@modelcontextprotocol/sdk/server/auth/errors.js";
 import { InMemoryClientsStore } from "./clients-store.js";
 import { ElnoraConfig, AuthorizationSession, TokenRecord } from "../types.js";
 import { logAuthEvent } from "../middleware/tool-logging.js";
@@ -52,6 +53,11 @@ export class ElnoraOAuthProvider implements OAuthServerProvider {
   constructor(config: ElnoraConfig) {
     this.config = config;
     this._clientsStore = new InMemoryClientsStore();
+  }
+
+  /** Headers required by the platform's token validation endpoint */
+  private get validationHeaders() {
+    return { "X-Service-Key": this.config.mcpServiceKey };
   }
 
   get clientsStore(): OAuthRegisteredClientsStore {
@@ -211,7 +217,7 @@ export class ElnoraOAuthProvider implements OAuthServerProvider {
       const validation = await axios.post(
         this.config.tokenValidationUrl,
         { token: record.platformToken },
-        { timeout: REQUEST_TIMEOUT_MS },
+        { timeout: REQUEST_TIMEOUT_MS, headers: this.validationHeaders },
       );
       if (!validation.data.valid) {
         this.tokenRecords.delete(accessTokenKey);
@@ -257,14 +263,14 @@ export class ElnoraOAuthProvider implements OAuthServerProvider {
   async verifyAccessToken(token: string): Promise<AuthInfo> {
     const record = this.tokenRecords.get(token);
     if (!record) {
-      throw new Error("Invalid access token");
+      throw new InvalidTokenError("Invalid access token");
     }
 
     if (record.expiresAt < Math.floor(Date.now() / 1000)) {
       this.tokenRecords.delete(token);
       this.validationCache.delete(token);
       this.refreshTokenIndex.delete(record.refreshToken);
-      throw new Error("Access token expired");
+      throw new InvalidTokenError("Access token expired");
     }
 
     // Check validation cache — skip platform round-trip if recently validated
@@ -285,31 +291,31 @@ export class ElnoraOAuthProvider implements OAuthServerProvider {
       const validation = await axios.post(
         this.config.tokenValidationUrl,
         { token: record.platformToken },
-        { timeout: REQUEST_TIMEOUT_MS },
+        { timeout: REQUEST_TIMEOUT_MS, headers: this.validationHeaders },
       );
       if (!validation.data.valid) {
         this.tokenRecords.delete(token);
         this.validationCache.delete(token);
         this.refreshTokenIndex.delete(record.refreshToken);
-        throw new Error("Underlying platform token revoked");
+        throw new InvalidTokenError("Underlying platform token revoked");
       }
       // Cache successful validation
       this.validationCache.set(token, Math.floor(Date.now() / 1000));
     } catch (error) {
       // Re-throw our own revocation errors (from the valid:false check above)
-      if (error instanceof Error && error.message === "Underlying platform token revoked") {
+      if (error instanceof InvalidTokenError) {
         throw error;
       }
       if (axios.isAxiosError(error) && error.response?.status === 401) {
         this.tokenRecords.delete(token);
         this.validationCache.delete(token);
         this.refreshTokenIndex.delete(record.refreshToken);
-        throw new Error("Underlying platform token revoked");
+        throw new InvalidTokenError("Underlying platform token revoked");
       }
       // Network errors — fail-closed for security (SOC 2 / pharma revocation requirements).
       // Reject the request and force retry on next call.
       logAuthEvent("platform_validation_network_error", record.clientId, { error: String(error) });
-      throw new Error("Platform token validation unavailable — please retry");
+      throw new ServerError("Platform token validation unavailable — please retry");
     }
 
     return {

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,6 +32,7 @@ function loadConfig(): ElnoraConfig {
     tokenExchangeUrl: requireEnv("ELNORA_TOKEN_EXCHANGE_URL"),
     platformClientId: requireEnv("ELNORA_PLATFORM_CLIENT_ID"),
     platformClientSecret: requireEnv("ELNORA_PLATFORM_CLIENT_SECRET"),
+    mcpServiceKey: requireEnv("ELNORA_MCP_SERVICE_KEY"),
   };
 }
 
@@ -48,7 +49,7 @@ async function validateApiKeyWithPlatform(
     const validation = await axios.post(
       config.tokenValidationUrl,
       { token: apiKey },
-      { timeout: 10_000 },
+      { timeout: 10_000, headers: { "X-Service-Key": config.mcpServiceKey } },
     );
     if (validation.data.valid && validation.data.user_id) {
       return { userId: String(validation.data.user_id) };

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,6 +12,8 @@ export interface ElnoraConfig {
   platformClientId: string;
   /** Client secret for the MCP server as an OAuth client of the Elnora platform */
   platformClientSecret: string;
+  /** Service key for authenticating to the platform's token validation endpoint */
+  mcpServiceKey: string;
 }
 
 /** Stored authorization session for PKCE flow */

--- a/tests/auth/provider-advanced.test.ts
+++ b/tests/auth/provider-advanced.test.ts
@@ -20,6 +20,7 @@ const config: ElnoraConfig = {
   tokenExchangeUrl: "https://api.example.com/oauth/token",
   platformClientId: "mcp-server",
   platformClientSecret: "secret",
+  mcpServiceKey: "test-service-key",
 };
 
 /** Helper: run the full authorize → callback → exchange flow to get tokens */

--- a/tests/auth/provider.test.ts
+++ b/tests/auth/provider.test.ts
@@ -20,6 +20,7 @@ const config: ElnoraConfig = {
   tokenExchangeUrl: "https://api.example.com/oauth/token",
   platformClientId: "mcp-server",
   platformClientSecret: "secret",
+  mcpServiceKey: "test-service-key",
 };
 
 describe("ElnoraOAuthProvider", () => {

--- a/tests/middleware/cors.test.ts
+++ b/tests/middleware/cors.test.ts
@@ -11,6 +11,7 @@ const config: ElnoraConfig = {
   tokenExchangeUrl: "https://api.elnora.ai/oauth/token",
   platformClientId: "mcp-server",
   platformClientSecret: "secret",
+  mcpServiceKey: "test-service-key",
 };
 
 function mockReq(origin?: string, method = "POST") {

--- a/tests/tools/org-context.test.ts
+++ b/tests/tools/org-context.test.ts
@@ -11,6 +11,7 @@ const mockConfig: ElnoraConfig = {
   tokenExchangeUrl: "https://platform.elnora.ai/api/v1/auth/token",
   platformClientId: "test",
   platformClientSecret: "test",
+  mcpServiceKey: "test-service-key",
 };
 
 describe("ElnoraApiClient org context", () => {

--- a/tests/tools/tool-registration.test.ts
+++ b/tests/tools/tool-registration.test.ts
@@ -14,6 +14,7 @@ const mockConfig: ElnoraConfig = {
   tokenExchangeUrl: "https://platform.elnora.ai/api/v1/auth/token",
   platformClientId: "test",
   platformClientSecret: "test",
+  mcpServiceKey: "test-service-key",
 };
 
 function createTestContext(): RequestContext {


### PR DESCRIPTION
## Summary
- **Root cause**: The platform's `/auth/validate-token` endpoint requires an `X-Service-Key` header. The MCP server never sent it, so every `verifyAccessToken` call got 401 → interpreted as "token revoked" → thrown as plain `Error` → SDK wrapped as generic 500 `"Internal Server Error"` → Claude Code connection failure.
- Add `mcpServiceKey` to `ElnoraConfig` and pass `X-Service-Key` header on all platform validation calls (OAuth token verification + API key validation)
- Use SDK error types (`InvalidTokenError`, `ServerError`) instead of plain `Error` in `verifyAccessToken` so the SDK's `requireBearerAuth` middleware returns proper 401/500 responses

## Deployment
Requires `ELNORA_MCP_SERVICE_KEY` env var set in the MCP server's environment, matching the platform's `ServiceAuth:McpServiceKey` value.

## Test plan
- [x] `npm run build` — no type errors
- [x] `npm test` — all 106 tests pass
- [ ] Deploy with `ELNORA_MCP_SERVICE_KEY` set and verify Claude Code connects successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)