### PR TITLE
feat(ci): switch GitHub Actions from static AWS keys to OIDC federation

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,12 +6,14 @@ on:
   workflow_dispatch:
 
 permissions:
+  id-token: write
   contents: read
 
 env:
-  AWS_REGION: ${{ secrets.AWS_REGION }}
-  AWS_ECR_REGISTRY: ${{ secrets.AWS_ECR_REGISTRY }}
-  AWS_CLUSTER: ${{ secrets.AWS_CLUSTER }}
+  AWS_REGION: us-east-1
+  AWS_ECR_REGISTRY: 551507900153.dkr.ecr.us-east-1.amazonaws.com
+  AWS_CLUSTER: production
+  AWS_ROLE_ARN: arn:aws:iam::551507900153:role/elnora-github-actions-deploy
 
 jobs:
   deploy:
@@ -29,8 +31,7 @@ jobs:
           exit 1
       - uses: aws-actions/configure-aws-credentials@v4
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role-to-assume: ${{ env.AWS_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}
       - uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
## Summary
- Replace long-lived secrets with short-lived OIDC tokens
- Uses an IAM role
- Adds `permissions: id-token: write` for OIDC token exchange
- Hardcodes AWS region/registry/cluster (no longer needs secrets for these)

## Test plan
- [ ] Merge and trigger a manual deploy from main
- [ ] Verify ECR push succeeds
- [ ] Verify ECS service update and stabilization succeeds
- [ ] Delete `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` secrets from repo settings

🤖 Generated with [Claude Code](https://claude.com/claude-code)