### PR TITLE
fix: enable trust proxy for ALB compatibility

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -82,6 +82,10 @@ async function main(): Promise<void> {
 
   const app = express();
 
+  // Trust one proxy hop (ALB) so X-Forwarded-For is used for req.ip
+  // Required for express-rate-limit to identify clients correctly behind ALB
+  app.set("trust proxy", 1);
+
   // --- Security middleware (CoSAI MCP-T7) ---
   app.use(corsMiddleware(config));
   app.use(express.json({ limit: "1mb" })); // Payload size limit (CoSAI MCP-T10)


### PR DESCRIPTION
## Summary
- Adds `app.set("trust proxy", 1)` to the Express app so that `X-Forwarded-For` headers from the ALB are correctly used for `req.ip`
- Fixes `ERR_ERL_UNEXPECTED_X_FORWARDED_FOR` errors (500s) from `express-rate-limit` when running behind the ALB in production

## Context
During hackathon monitoring, we observed intermittent 5XX errors from the mcp-server target group. CloudWatch logs showed `express-rate-limit` throwing `ValidationError` because Express didn't know it was behind a proxy, so `X-Forwarded-For` headers were unexpected.

## Test plan
- [ ] Verify mcp-server starts without errors locally
- [ ] Deploy to production and confirm 5XX errors from mcp-server stop
- [ ] Verify rate limiting still works correctly (clients are identified by real IP, not ALB IP)

🤖 Generated with [Claude Code](https://claude.com/claude-code)