### PR TITLE
fix: override tar and minimatch to resolve remaining CVEs

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,9 @@
     "zod": "^4.3.6"
   },
   "overrides": {
-    "hono": "^4.12.7"
+    "hono": "^4.12.7",
+    "tar": "^7.5.11",
+    "minimatch": "^10.2.4"
   },
   "devDependencies": {
     "@types/express": "^5.0.0",


### PR DESCRIPTION
## Summary

Add npm overrides for `tar` (^7.5.11) and `minimatch` (^10.2.4) to resolve 6 CVEs in npm 11's bundled versions that shipped with Node 24.

- tar 7.5.7 → 7.5.11+ (CVE-2026-26960, CVE-2026-29786, CVE-2026-31802)
- minimatch 10.1.2 → 10.2.4+ (CVE-2026-26996, CVE-2026-27903, CVE-2026-27904)

## Test plan

- [x] `npm run build` — passes
- [x] `npm test` — 106 tests pass
- [ ] Deploy and verify health endpoint
- [ ] Verify AWS Inspector clears tar/minimatch findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)