### PR TITLE
fix: upgrade picomatch to 4.0.4 for CVE-2026-33672

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2504,9 +2504,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {


### PR DESCRIPTION
## Summary
Upgrade picomatch 4.0.3 → 4.0.4 to fix method injection vulnerability in POSIX character classes.

Fixes SEC-257

## Changes
- `package-lock.json`: picomatch 4.0.3 → 4.0.4

## Test plan
- [ ] Verify build succeeds
- [ ] Confirm no runtime regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)