### PR TITLE
fix: update node:24-slim base image digest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:24-slim@sha256:d8e448a56fc63242f70026718378bd4b00f8c82e78d20eefb199224a4d8e33d8 AS builder
+FROM node:24-slim@sha256:06e5c9f86bfa0aaa7163cf37a5eaa8805f16b9acb48e3f85645b09d459fc2a9f AS builder
 WORKDIR /app
 COPY package.json package-lock.json ./
 RUN npm ci --ignore-scripts
@@ -6,7 +6,7 @@ COPY tsconfig.json ./
 COPY src/ ./src/
 RUN npm run build
 
-FROM node:24-slim@sha256:d8e448a56fc63242f70026718378bd4b00f8c82e78d20eefb199224a4d8e33d8
+FROM node:24-slim@sha256:06e5c9f86bfa0aaa7163cf37a5eaa8805f16b9acb48e3f85645b09d459fc2a9f
 WORKDIR /app
 ENV NODE_ENV=production
 COPY --from=builder /app/package.json /app/package-lock.json ./


### PR DESCRIPTION
## Summary
- Updates the pinned `node:24-slim` Docker base image digest to the latest version
- Old digest: `sha256:d8e448a56fc63242f70026718378bd4b00f8c82e78d20eefb199224a4d8e33d8`
- New digest: `sha256:06e5c9f86bfa0aaa7163cf37a5eaa8805f16b9acb48e3f85645b09d459fc2a9f`
- Docker build verified locally — builds and runs correctly

## Note on OS-level CVEs
Some Inspector findings (ncurses, openssl, systemd) are from the Debian 12 base and may persist until Debian releases patches upstream. This update picks up any OS patches available in the latest `node:24-slim` build.

## Test plan
- [x] Docker build succeeds locally
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)