### PR TITLE
fix: persist OAuth client registrations in Redis (ELN-570)

### DIFF
--- a/src/auth/provider.ts
+++ b/src/auth/provider.ts
@@ -10,7 +10,6 @@ import {
 } from "@modelcontextprotocol/sdk/shared/auth.js";
 import { AuthInfo } from "@modelcontextprotocol/sdk/server/auth/types.js";
 import { InvalidTokenError, ServerError } from "@modelcontextprotocol/sdk/server/auth/errors.js";
-import { InMemoryClientsStore } from "./clients-store.js";
 import { TokenStore } from "./token-store.js";
 import { ElnoraConfig, TokenRecord } from "../types.js";
 import { logAuthEvent } from "../middleware/tool-logging.js";
@@ -44,14 +43,14 @@ import {
 const VALIDATION_CACHE_TTL_SECONDS = 30;
 
 export class ElnoraOAuthProvider implements OAuthServerProvider {
-  private _clientsStore: InMemoryClientsStore;
+  private _clientsStore: OAuthRegisteredClientsStore;
   private store: TokenStore;
   private config: ElnoraConfig;
 
-  constructor(config: ElnoraConfig, store: TokenStore) {
+  constructor(config: ElnoraConfig, store: TokenStore, clientsStore: OAuthRegisteredClientsStore) {
     this.config = config;
     this.store = store;
-    this._clientsStore = new InMemoryClientsStore();
+    this._clientsStore = clientsStore;
   }
 
   /** Headers required by the platform's token validation endpoint */
@@ -396,7 +395,7 @@ export class ElnoraOAuthProvider implements OAuthServerProvider {
     logAuthEvent("platform_callback_completed", session.clientId);
 
     // Validate redirect_uri against registered client before redirecting (prevents open redirect)
-    const clientRecord = this._clientsStore.getClient(session.clientId);
+    const clientRecord = await this._clientsStore.getClient(session.clientId);
     if (!clientRecord?.redirect_uris?.includes(session.redirectUri)) {
       logAuthEvent("redirect_uri_not_registered", session.clientId, { redirectUri: session.redirectUri });
       throw new Error("Redirect URI not registered for client");

--- a/src/auth/redis-clients-store.ts
+++ b/src/auth/redis-clients-store.ts
@@ -1,0 +1,87 @@
+import crypto from "node:crypto";
+import { Redis } from "ioredis";
+import { OAuthRegisteredClientsStore } from "@modelcontextprotocol/sdk/server/auth/clients.js";
+import { OAuthClientInformationFull } from "@modelcontextprotocol/sdk/shared/auth.js";
+import { CLIENT_SECRET_TTL_SECONDS } from "../constants.js";
+
+const PREFIX_CLIENT = "elnora:mcp:client:";
+
+/**
+ * Redis-backed OAuth client store supporting Dynamic Client Registration (RFC 7591).
+ *
+ * Persists client registrations across server restarts via Redis.
+ * Key layout: elnora:mcp:client:{clientId} → JSON OAuthClientInformationFull (90-day TTL)
+ */
+export class RedisClientsStore implements OAuthRegisteredClientsStore {
+  private redis: Redis;
+
+  constructor(redisUrl: string) {
+    this.redis = new Redis(redisUrl, {
+      maxRetriesPerRequest: 3,
+      retryStrategy(times: number) {
+        return Math.min(times * 100, 5000);
+      },
+      enableReadyCheck: true,
+      lazyConnect: false,
+    });
+  }
+
+  async getClient(clientId: string): Promise<OAuthClientInformationFull | undefined> {
+    const data = await this.redis.get(`${PREFIX_CLIENT}${clientId}`);
+    return data ? JSON.parse(data) : undefined;
+  }
+
+  async registerClient(
+    client: Omit<OAuthClientInformationFull, "client_id" | "client_id_issued_at">,
+  ): Promise<OAuthClientInformationFull> {
+    // Validate redirect_uri schemes — HTTPS required, HTTP only for localhost (CoSAI MCP-T7)
+    if (client.redirect_uris) {
+      for (const uri of client.redirect_uris) {
+        let parsed: URL;
+        try {
+          parsed = new URL(uri);
+        } catch {
+          throw new Error(`Invalid redirect_uri: ${uri}`);
+        }
+        if (parsed.protocol !== "https:" && parsed.protocol !== "http:") {
+          throw new Error(`redirect_uri must use HTTPS (got ${parsed.protocol}): ${uri}`);
+        }
+        if (parsed.protocol === "http:" && !["localhost", "127.0.0.1"].includes(parsed.hostname)) {
+          throw new Error(`HTTP redirect_uri only allowed for localhost: ${uri}`);
+        }
+      }
+    }
+
+    const clientId = crypto.randomUUID();
+    const clientSecret = crypto.randomBytes(32).toString("base64url");
+    const now = Math.floor(Date.now() / 1000);
+
+    const registered: OAuthClientInformationFull = {
+      ...client,
+      client_id: clientId,
+      client_id_issued_at: now,
+      client_secret: clientSecret,
+      client_secret_expires_at: now + CLIENT_SECRET_TTL_SECONDS,
+    };
+
+    await this.redis.set(
+      `${PREFIX_CLIENT}${clientId}`,
+      JSON.stringify(registered),
+      "EX",
+      CLIENT_SECRET_TTL_SECONDS,
+    );
+
+    return registered;
+  }
+
+  async ping(): Promise<void> {
+    const result = await this.redis.ping();
+    if (result !== "PONG") {
+      throw new Error(`Redis ping failed: ${result}`);
+    }
+  }
+
+  async disconnect(): Promise<void> {
+    await this.redis.quit();
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ import { corsMiddleware } from "./middleware/cors.js";
 import { SUPPORTED_SCOPES, ALL_SCOPES } from "./constants.js";
 import { logAuthEvent } from "./middleware/tool-logging.js";
 import { RedisTokenStore } from "./auth/redis-token-store.js";
+import { RedisClientsStore } from "./auth/redis-clients-store.js";
 import { TokenStore } from "./auth/token-store.js";
 import rateLimit from "express-rate-limit";
 import axios from "axios";
@@ -75,10 +76,14 @@ async function main(): Promise<void> {
     }
   }
 
-  // --- Redis token store (fail-closed — server won't start without Redis) ---
+  // --- Redis stores (fail-closed — server won't start without Redis) ---
   const store: TokenStore = new RedisTokenStore(config.redisUrl);
   await store.ping();
   console.error("Redis token store connected");
+
+  const clientsStore = new RedisClientsStore(config.redisUrl);
+  await clientsStore.ping();
+  console.error("Redis clients store connected");
 
   const app = express();
 
@@ -112,7 +117,7 @@ async function main(): Promise<void> {
   });
 
   // --- OAuth 2.1 Authorization Server ---
-  const provider = new ElnoraOAuthProvider(config, store);
+  const provider = new ElnoraOAuthProvider(config, store, clientsStore);
   const issuerUrl = new URL(config.publicUrl);
   const mcpServerUrl = new URL(`${config.publicUrl}/mcp`);
 
@@ -335,6 +340,7 @@ async function main(): Promise<void> {
   const gracefulShutdown = async (signal: string) => {
     console.error(`${signal} received — shutting down gracefully`);
     httpServer.close(async () => {
+      await clientsStore.disconnect();
       await store.disconnect();
       process.exit(0);
     });

--- a/tests/auth/provider-advanced.test.ts
+++ b/tests/auth/provider-advanced.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { ElnoraOAuthProvider } from "../../src/auth/provider.js";
 import { InMemoryTokenStore } from "../../src/auth/in-memory-token-store.js";
+import { InMemoryClientsStore } from "../../src/auth/clients-store.js";
 import type { ElnoraConfig } from "../../src/types.js";
 
 vi.mock("axios", () => ({
@@ -28,7 +29,7 @@ const config: ElnoraConfig = {
 /** Helper: run the full authorize → callback → exchange flow to get tokens */
 async function issueTokens(provider: ElnoraOAuthProvider) {
   // Register client in the store so handlePlatformCallback can validate redirect_uri
-  const registered = provider.clientsStore.registerClient({
+  const registered = await provider.clientsStore.registerClient!({
     redirect_uris: ["http://localhost:3000/callback"],
   });
   const client = { client_id: registered.client_id, redirect_uris: ["http://localhost:3000/callback"] };
@@ -60,7 +61,7 @@ describe("ElnoraOAuthProvider — advanced flows", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    provider = new ElnoraOAuthProvider(config, new InMemoryTokenStore());
+    provider = new ElnoraOAuthProvider(config, new InMemoryTokenStore(), new InMemoryClientsStore());
   });
 
   describe("verifyAccessToken", () => {
@@ -224,7 +225,7 @@ describe("ElnoraOAuthProvider — advanced flows", () => {
 
   describe("handlePlatformCallback", () => {
     it("throws on callback replay (same code used twice)", async () => {
-      const registered = provider.clientsStore.registerClient({
+      const registered = await provider.clientsStore.registerClient!({
         redirect_uris: ["http://localhost:3000/callback"],
       });
       const client = { client_id: registered.client_id, redirect_uris: ["http://localhost:3000/callback"] };

--- a/tests/auth/provider.test.ts
+++ b/tests/auth/provider.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { ElnoraOAuthProvider } from "../../src/auth/provider.js";
 import { InMemoryTokenStore } from "../../src/auth/in-memory-token-store.js";
+import { InMemoryClientsStore } from "../../src/auth/clients-store.js";
 import type { ElnoraConfig } from "../../src/types.js";
 
 vi.mock("axios", () => ({
@@ -30,7 +31,7 @@ describe("ElnoraOAuthProvider", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    provider = new ElnoraOAuthProvider(config, new InMemoryTokenStore());
+    provider = new ElnoraOAuthProvider(config, new InMemoryTokenStore(), new InMemoryClientsStore());
   });
 
   describe("clientsStore", () => {
@@ -96,7 +97,7 @@ describe("ElnoraOAuthProvider", () => {
 
   describe("exchangeAuthorizationCode", () => {
     it("exchanges code for tokens via platform and issues MCP tokens", async () => {
-      const registered = provider.clientsStore.registerClient({
+      const registered = await provider.clientsStore.registerClient!({
         redirect_uris: ["http://localhost:3000/callback"],
       });
       const client = { client_id: registered.client_id, redirect_uris: ["http://localhost:3000/callback"] };
@@ -137,7 +138,7 @@ describe("ElnoraOAuthProvider", () => {
     });
 
     it("throws when platform callback not completed", async () => {
-      const registered = provider.clientsStore.registerClient({
+      const registered = await provider.clientsStore.registerClient!({
         redirect_uris: ["http://localhost:3000/callback"],
       });
       const client = { client_id: registered.client_id, redirect_uris: ["http://localhost:3000/callback"] };
@@ -159,7 +160,7 @@ describe("ElnoraOAuthProvider", () => {
     });
 
     it("throws when redirect_uri does not match authorization request", async () => {
-      const registered = provider.clientsStore.registerClient({
+      const registered = await provider.clientsStore.registerClient!({
         redirect_uris: ["http://localhost:3000/callback"],
       });
       const client = { client_id: registered.client_id, redirect_uris: ["http://localhost:3000/callback"] };
@@ -252,7 +253,7 @@ describe("ElnoraOAuthProvider", () => {
     });
 
     it("throws on state mismatch (CSRF protection)", async () => {
-      const registered = provider.clientsStore.registerClient({
+      const registered = await provider.clientsStore.registerClient!({
         redirect_uris: ["http://localhost:3000/callback"],
       });
       const client = { client_id: registered.client_id, redirect_uris: ["http://localhost:3000/callback"] };
@@ -274,7 +275,7 @@ describe("ElnoraOAuthProvider", () => {
     });
 
     it("throws on empty platform code", async () => {
-      const registered = provider.clientsStore.registerClient({
+      const registered = await provider.clientsStore.registerClient!({
         redirect_uris: ["http://localhost:3000/callback"],
       });
       const client = { client_id: registered.client_id, redirect_uris: ["http://localhost:3000/callback"] };
@@ -296,7 +297,7 @@ describe("ElnoraOAuthProvider", () => {
     });
 
     it("builds redirect URL with code and state", async () => {
-      const registered = provider.clientsStore.registerClient({
+      const registered = await provider.clientsStore.registerClient!({
         redirect_uris: ["http://localhost:3000/callback"],
       });
       const client = { client_id: registered.client_id, redirect_uris: ["http://localhost:3000/callback"] };

--- a/tests/auth/redis-clients-store.integration.test.ts
+++ b/tests/auth/redis-clients-store.integration.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from "vitest";
+import { Redis } from "ioredis";
+import { RedisClientsStore } from "../../src/auth/redis-clients-store.js";
+
+const REDIS_URL = process.env.REDIS_URL || "redis://localhost:6379";
+const TEST_PREFIX = "elnora:mcp:client:";
+
+let store: RedisClientsStore;
+let cleanupRedis: Redis;
+let redisAvailable = false;
+
+beforeAll(async () => {
+  try {
+    cleanupRedis = new Redis(REDIS_URL, { maxRetriesPerRequest: 1, connectTimeout: 2000 });
+    await cleanupRedis.ping();
+    redisAvailable = true;
+    store = new RedisClientsStore(REDIS_URL);
+  } catch {
+    // Redis not available — tests will be skipped
+  }
+});
+
+afterAll(async () => {
+  if (redisAvailable) {
+    await store.disconnect();
+    await cleanupRedis.quit();
+  }
+});
+
+beforeEach(async () => {
+  if (!redisAvailable) return;
+  // Clean up test keys
+  const keys = await cleanupRedis.keys(`${TEST_PREFIX}*`);
+  if (keys.length > 0) {
+    await cleanupRedis.del(...keys);
+  }
+});
+
+describe.skipIf(!redisAvailable)("RedisClientsStore integration", () => {
+  describe("ping", () => {
+    it("succeeds when Redis is available", async () => {
+      await expect(store.ping()).resolves.not.toThrow();
+    });
+  });
+
+  describe("getClient", () => {
+    it("returns undefined for unregistered client", async () => {
+      const result = await store.getClient("nonexistent");
+      expect(result).toBeUndefined();
+    });
+  });
+
+  describe("registerClient", () => {
+    it("registers a client and returns it with generated id and secret", async () => {
+      const registered = await store.registerClient({
+        redirect_uris: ["http://localhost:3000/callback"],
+        token_endpoint_auth_method: "client_secret_post",
+      });
+
+      expect(registered.client_id).toBeDefined();
+      expect(registered.client_secret).toBeDefined();
+      expect(registered.client_id_issued_at).toBeGreaterThan(0);
+      expect(registered.client_secret_expires_at).toBeGreaterThan(registered.client_id_issued_at!);
+      expect(registered.redirect_uris).toEqual(["http://localhost:3000/callback"]);
+    });
+
+    it("retrieves a registered client by ID", async () => {
+      const registered = await store.registerClient({
+        redirect_uris: ["http://localhost:3000/callback"],
+      });
+
+      const retrieved = await store.getClient(registered.client_id);
+      expect(retrieved).toEqual(registered);
+    });
+
+    it("round-trips all client fields correctly", async () => {
+      const registered = await store.registerClient({
+        redirect_uris: ["https://app.example.com/callback", "http://localhost:3000/callback"],
+        token_endpoint_auth_method: "client_secret_post",
+        grant_types: ["authorization_code", "refresh_token"],
+        response_types: ["code"],
+        scope: "tasks:read tasks:write",
+      });
+
+      const retrieved = await store.getClient(registered.client_id);
+      expect(retrieved).toEqual(registered);
+      expect(retrieved!.redirect_uris).toEqual(["https://app.example.com/callback", "http://localhost:3000/callback"]);
+      expect(retrieved!.token_endpoint_auth_method).toBe("client_secret_post");
+      expect(retrieved!.grant_types).toEqual(["authorization_code", "refresh_token"]);
+    });
+
+    it("generates unique IDs for each registered client", async () => {
+      const client1 = await store.registerClient({ redirect_uris: ["http://localhost:3001/callback"] });
+      const client2 = await store.registerClient({ redirect_uris: ["http://localhost:3002/callback"] });
+
+      expect(client1.client_id).not.toBe(client2.client_id);
+      expect(client1.client_secret).not.toBe(client2.client_secret);
+    });
+
+    it("sets TTL on client key", async () => {
+      const registered = await store.registerClient({
+        redirect_uris: ["http://localhost:3000/callback"],
+      });
+
+      const ttl = await cleanupRedis.ttl(`${TEST_PREFIX}${registered.client_id}`);
+      expect(ttl).toBeGreaterThan(0);
+      // 90 days = 7776000 seconds — allow small variance for test execution time
+      expect(ttl).toBeLessThanOrEqual(90 * 24 * 3600);
+      expect(ttl).toBeGreaterThan(90 * 24 * 3600 - 60);
+    });
+  });
+
+  describe("redirect URI validation", () => {
+    it("rejects non-localhost HTTP redirect URIs", async () => {
+      await expect(
+        store.registerClient({ redirect_uris: ["http://evil.example.com/callback"] }),
+      ).rejects.toThrow("HTTP redirect_uri only allowed for localhost");
+    });
+
+    it("rejects javascript: redirect URIs", async () => {
+      await expect(
+        store.registerClient({ redirect_uris: ["javascript:alert(1)"] }),
+      ).rejects.toThrow("redirect_uri must use HTTPS");
+    });
+
+    it("rejects data: redirect URIs", async () => {
+      await expect(
+        store.registerClient({ redirect_uris: ["data:text/html,<h1>hi</h1>"] }),
+      ).rejects.toThrow("redirect_uri must use HTTPS");
+    });
+
+    it("accepts HTTPS redirect URIs", async () => {
+      const registered = await store.registerClient({
+        redirect_uris: ["https://app.example.com/callback"],
+      });
+      expect(registered.redirect_uris).toEqual(["https://app.example.com/callback"]);
+    });
+
+    it("accepts localhost HTTP redirect URIs", async () => {
+      const registered = await store.registerClient({
+        redirect_uris: ["http://localhost:3000/callback"],
+      });
+      expect(registered.redirect_uris).toEqual(["http://localhost:3000/callback"]);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- **Add `RedisClientsStore`** — Redis-backed `OAuthRegisteredClientsStore` persisting client registrations across deploys (`elnora:mcp:client:{id}` keys, 90-day TTL)
- **Fix `handlePlatformCallback`** — `await getClient()` so it works with async Redis store (was synchronous, returning a truthy Promise instead of the client record)
- **Constructor injection** — `ElnoraOAuthProvider` now accepts a clients store parameter instead of hard-coding `InMemoryClientsStore`

Closes ELN-570

## Test plan

- [x] TypeScript compiles clean (`tsc --noEmit`)
- [x] All 106 unit tests pass (`vitest run`)
- [x] Integration test file added (`redis-clients-store.integration.test.ts`) — skipped without Redis, covers: register/retrieve, unique IDs, TTL, redirect URI validation, data round-trip
- [ ] Manual verification: register client → restart server → client persists in Redis
- [ ] Deploy to staging → verify no re-auth needed after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)