### PR TITLE
fix(deps): resolve SEC-274, SEC-275, SEC-276 dependency vulnerabilities

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,8 @@ FROM node:24-slim@sha256:06e5c9f86bfa0aaa7163cf37a5eaa8805f16b9acb48e3f85645b09d
 WORKDIR /app
 ENV NODE_ENV=production
 COPY --from=builder /app/package.json /app/package-lock.json ./
-RUN npm ci --omit=dev --ignore-scripts
+RUN npm ci --omit=dev --ignore-scripts && \
+    rm -rf /usr/local/lib/node_modules/npm /usr/local/bin/npm /usr/local/bin/npx
 COPY --from=builder /app/dist ./dist
 
 EXPOSE 3000

--- a/package-lock.json
+++ b/package-lock.json
@@ -2480,9 +2480,9 @@
       }
     },
     "node_modules/path-to-regexp": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
-      "integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
+      "version": "8.4.1",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.1.tgz",
+      "integrity": "sha512-fvU78fIjZ+SBM9YwCknCvKOUKkLVqtWDVctl0s7xIqfmfb38t2TT4ZU2gHm+Z8xGwgW+QWEU3oQSAzIbo89Ggw==",
       "license": "MIT",
       "funding": {
         "type": "opencollective",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,8 @@
   "overrides": {
     "hono": "^4.12.7",
     "tar": "^7.5.11",
-    "minimatch": "^10.2.4"
+    "minimatch": "^10.2.4",
+    "path-to-regexp": "^8.4.0"
   },
   "devDependencies": {
     "@types/express": "^5.0.0",


### PR DESCRIPTION
## Summary

- **Override `path-to-regexp` to `^8.4.0`** — fixes CVE-2026-4926 (HIGH, CVSS 7.5) and CVE-2026-4923 (MEDIUM, CVSS 5.9), both ReDoS vulnerabilities in Express's router dependency
- **Remove npm/npx from production Docker image** — eliminates CVE-2026-33750 (MEDIUM, CVSS 6.5) in `brace-expansion`, which is bundled in Node's npm and not used at runtime

### Changes

| File | Change |
|------|--------|
| `package.json` | Added `path-to-regexp: "^8.4.0"` to overrides |
| `package-lock.json` | Regenerated — `path-to-regexp` 8.3.0 → 8.4.1 |
| `Dockerfile` | Chain `rm -rf` of npm/npx after `npm ci` in production stage |

### Linear Issues

Fixes SEC-276
Fixes SEC-275
Fixes SEC-274

## Test plan

- [x] `npm test` — all 106 tests pass
- [x] `npm audit` — 0 vulnerabilities
- [ ] Verify Docker build succeeds
- [ ] Verify AWS Inspector rescan shows resolved CVEs after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)