### PR TITLE
feat: consume platform refresh tokens for 30-day MCP sessions (ELN-513)

### DIFF
--- a/src/auth/provider.ts
+++ b/src/auth/provider.ts
@@ -42,6 +42,14 @@ import {
 /** TTL for platform token validation cache (seconds) */
 const VALIDATION_CACHE_TTL_SECONDS = 30;
 
+/** Extract a safe error message from Axios errors without leaking request body (which contains secrets). */
+function safeErrorMessage(error: unknown): string {
+  if (axios.isAxiosError(error)) {
+    return `${error.response?.status ?? "network"}: ${error.message}`;
+  }
+  return error instanceof Error ? error.message : "Unknown error";
+}
+
 export class ElnoraOAuthProvider implements OAuthServerProvider {
   private _clientsStore: OAuthRegisteredClientsStore;
   private store: TokenStore;
@@ -155,8 +163,9 @@ export class ElnoraOAuthProvider implements OAuthServerProvider {
     // If the platform exchange fails transiently, the session survives so the user
     // can retry without restarting the full auth flow.
     let platformToken: string;
+    let platformRefreshToken: string | undefined;
     try {
-      const response = await axios.post<{ access_token: string }>(
+      const response = await axios.post<{ access_token: string; refresh_token?: string }>(
         this.config.tokenExchangeUrl,
         {
           grant_type: "authorization_code",
@@ -167,8 +176,9 @@ export class ElnoraOAuthProvider implements OAuthServerProvider {
         { timeout: REQUEST_TIMEOUT_MS },
       );
       platformToken = response.data.access_token;
+      platformRefreshToken = response.data.refresh_token;
     } catch (error) {
-      logAuthEvent("platform_token_exchange_failed", client.client_id, { error: String(error) });
+      logAuthEvent("platform_token_exchange_failed", client.client_id, { error: safeErrorMessage(error) });
       throw new Error("Failed to exchange authorization code with platform");
     }
 
@@ -176,7 +186,7 @@ export class ElnoraOAuthProvider implements OAuthServerProvider {
     await this.store.deleteSession(authorizationCode);
 
     // Issue MCP tokens (separate from platform token — CoSAI MCP-T1)
-    return this.issueTokens(client.client_id, session.scopes, platformToken, resource?.toString());
+    return this.issueTokens(client.client_id, session.scopes, platformToken, resource?.toString(), platformRefreshToken);
   }
 
   async exchangeRefreshToken(
@@ -232,7 +242,7 @@ export class ElnoraOAuthProvider implements OAuthServerProvider {
         logAuthEvent("refresh_platform_token_revoked", client.client_id);
         throw new Error("Underlying platform token has been revoked");
       }
-      logAuthEvent("refresh_platform_validation_error", client.client_id, { error: String(error) });
+      logAuthEvent("refresh_platform_validation_error", client.client_id, { error: safeErrorMessage(error) });
       throw new Error("Platform token validation unavailable — please retry");
     }
 
@@ -252,6 +262,7 @@ export class ElnoraOAuthProvider implements OAuthServerProvider {
       scopes || record.scopes,
       record.platformToken,
       resource?.toString() || record.resource,
+      record.platformRefreshToken,
     );
   }
 
@@ -289,10 +300,7 @@ export class ElnoraOAuthProvider implements OAuthServerProvider {
         { timeout: REQUEST_TIMEOUT_MS, headers: this.validationHeaders },
       );
       if (!validation.data.valid) {
-        await this.store.deleteTokenRecord(token);
-        await this.store.deleteValidationCache(token);
-        await this.store.deleteRefreshIndex(record.refreshToken);
-        throw new InvalidTokenError("Underlying platform token revoked");
+        return this.attemptRefreshOrRevoke(token, record);
       }
       // Cache successful validation
       await this.store.setValidationCache(token, Math.floor(Date.now() / 1000), VALIDATION_CACHE_TTL_SECONDS);
@@ -302,14 +310,11 @@ export class ElnoraOAuthProvider implements OAuthServerProvider {
         throw error;
       }
       if (axios.isAxiosError(error) && error.response?.status === 401) {
-        await this.store.deleteTokenRecord(token);
-        await this.store.deleteValidationCache(token);
-        await this.store.deleteRefreshIndex(record.refreshToken);
-        throw new InvalidTokenError("Underlying platform token revoked");
+        return this.attemptRefreshOrRevoke(token, record);
       }
       // Network errors — fail-closed for security (SOC 2 / pharma revocation requirements).
       // Reject the request and force retry on next call.
-      logAuthEvent("platform_validation_network_error", record.clientId, { error: String(error) });
+      logAuthEvent("platform_validation_network_error", record.clientId, { error: safeErrorMessage(error) });
       throw new ServerError("Platform token validation unavailable — please retry");
     }
 
@@ -410,11 +415,72 @@ export class ElnoraOAuthProvider implements OAuthServerProvider {
     return redirectUrl.toString();
   }
 
+  /**
+   * Attempt to refresh the platform token, update the stored record, and return AuthInfo.
+   * If refresh fails or no refresh token exists, revokes all tokens and throws.
+   */
+  private async attemptRefreshOrRevoke(token: string, record: TokenRecord): Promise<AuthInfo> {
+    if (record.platformRefreshToken) {
+      const refreshed = await this.refreshPlatformToken(record.platformRefreshToken, record.clientId);
+      if (refreshed) {
+        const updatedRecord: TokenRecord = {
+          ...record,
+          platformToken: refreshed.accessToken,
+          platformRefreshToken: refreshed.refreshToken || record.platformRefreshToken,
+        };
+        await this.store.setTokenRecord(token, updatedRecord, REFRESH_TOKEN_TTL_SECONDS);
+        await this.store.setValidationCache(token, Math.floor(Date.now() / 1000), VALIDATION_CACHE_TTL_SECONDS);
+        logAuthEvent("platform_token_refreshed", record.clientId);
+        return {
+          token,
+          clientId: record.clientId,
+          scopes: record.scopes,
+          expiresAt: record.expiresAt,
+          resource: record.resource ? new URL(record.resource) : undefined,
+        };
+      }
+    }
+    await this.store.deleteTokenRecord(token);
+    await this.store.deleteValidationCache(token);
+    await this.store.deleteRefreshIndex(record.refreshToken);
+    throw new InvalidTokenError("Underlying platform token revoked");
+  }
+
+  /**
+   * Attempt to refresh an expired platform token using the platform's refresh token.
+   * Returns new tokens on success, or null if refresh fails (caller falls back to revocation).
+   */
+  private async refreshPlatformToken(
+    platformRefreshToken: string,
+    clientId: string,
+  ): Promise<{ accessToken: string; refreshToken?: string } | null> {
+    try {
+      const response = await axios.post<{ access_token: string; refresh_token?: string }>(
+        this.config.tokenExchangeUrl,
+        {
+          grant_type: "refresh_token",
+          refresh_token: platformRefreshToken,
+          client_id: this.config.platformClientId,
+          client_secret: this.config.platformClientSecret,
+        },
+        { timeout: REQUEST_TIMEOUT_MS },
+      );
+      return {
+        accessToken: response.data.access_token,
+        refreshToken: response.data.refresh_token,
+      };
+    } catch (error) {
+      logAuthEvent("platform_token_refresh_failed", clientId, { error: safeErrorMessage(error) });
+      return null;
+    }
+  }
+
   private async issueTokens(
     clientId: string,
     scopes: string[],
     platformToken: string,
     resource?: string,
+    platformRefreshToken?: string,
   ): Promise<OAuthTokens> {
     const accessToken = crypto.randomBytes(32).toString("base64url");
     const refreshToken = crypto.randomBytes(32).toString("base64url");
@@ -424,6 +490,7 @@ export class ElnoraOAuthProvider implements OAuthServerProvider {
       accessToken,
       refreshToken,
       platformToken,
+      platformRefreshToken,
       clientId,
       scopes,
       resource,

--- a/src/middleware/tool-logging.ts
+++ b/src/middleware/tool-logging.ts
@@ -62,7 +62,7 @@ function sanitizeLogValue(value: string): string {
  * for fields that might contain user data.
  */
 const REDACT_CONTENT_KEYS = new Set(["content", "message", "description", "initial_message", "query"]);
-const REDACT_PII_KEYS = new Set(["email", "first_name", "last_name", "token", "platformToken", "apiKey"]);
+const REDACT_PII_KEYS = new Set(["email", "first_name", "last_name", "token", "platformToken", "platformRefreshToken", "refresh_token", "client_secret", "apiKey"]);
 const REDACT_ARRAY_KEYS = new Set(["file_ids", "context_file_ids", "scopes"]);
 
 function sanitizeParams(params: Record<string, unknown>): Record<string, unknown> {

--- a/src/types.ts
+++ b/src/types.ts
@@ -37,6 +37,7 @@ export interface TokenRecord {
   accessToken: string;
   refreshToken: string;
   platformToken: string;
+  platformRefreshToken?: string;
   clientId: string;
   scopes: string[];
   resource?: string;

--- a/tests/auth/provider-advanced.test.ts
+++ b/tests/auth/provider-advanced.test.ts
@@ -49,7 +49,7 @@ async function issueTokens(provider: ElnoraOAuthProvider) {
   await provider.handlePlatformCallback(mcpCode, "platform-auth-code", platformState);
 
   vi.mocked(axios.post).mockResolvedValueOnce({
-    data: { access_token: "platform-token-123" },
+    data: { access_token: "platform-token-123", refresh_token: "platform-refresh-token-123" },
   });
 
   const tokens = await provider.exchangeAuthorizationCode(client, mcpCode, undefined, "http://localhost:3000/callback");
@@ -323,6 +323,88 @@ describe("ElnoraOAuthProvider — advanced flows", () => {
       vi.mocked(axios.post).mockResolvedValueOnce({ data: { valid: true } });
       const authInfo = await provider.verifyAccessToken(tokens.access_token);
       expect(authInfo.token).toBe(tokens.access_token);
+    });
+  });
+
+  describe("platform token refresh", () => {
+    it("refreshes expired platform token when validation returns valid:false", async () => {
+      const { tokens } = await issueTokens(provider);
+
+      // Platform validation returns valid:false (token expired)
+      vi.mocked(axios.post).mockResolvedValueOnce({ data: { valid: false } });
+      // Platform refresh succeeds with new tokens
+      vi.mocked(axios.post).mockResolvedValueOnce({
+        data: { access_token: "new-platform-token", refresh_token: "new-platform-refresh-token" },
+      });
+
+      // Should succeed — platform token was refreshed transparently
+      const authInfo = await provider.verifyAccessToken(tokens.access_token);
+      expect(authInfo.token).toBe(tokens.access_token);
+      expect(authInfo.clientId).toBeDefined();
+    });
+
+    it("refreshes expired platform token when validation returns 401", async () => {
+      const { tokens } = await issueTokens(provider);
+
+      // Platform validation returns 401
+      const axiosError = new Error("Unauthorized") as Error & { response: { status: number } };
+      (axiosError as Record<string, unknown>).response = { status: 401 };
+      (axiosError as Record<string, unknown>).isAxiosError = true;
+      vi.mocked(axios.post).mockRejectedValueOnce(axiosError);
+      // Platform refresh succeeds
+      vi.mocked(axios.post).mockResolvedValueOnce({
+        data: { access_token: "new-platform-token", refresh_token: "new-platform-refresh-token" },
+      });
+
+      const authInfo = await provider.verifyAccessToken(tokens.access_token);
+      expect(authInfo.token).toBe(tokens.access_token);
+    });
+
+    it("revokes when platform token refresh fails", async () => {
+      const { tokens } = await issueTokens(provider);
+
+      // Platform validation returns valid:false
+      vi.mocked(axios.post).mockResolvedValueOnce({ data: { valid: false } });
+      // Platform refresh also fails
+      vi.mocked(axios.post).mockRejectedValueOnce(new Error("refresh failed"));
+
+      await expect(provider.verifyAccessToken(tokens.access_token)).rejects.toThrow(
+        "Underlying platform token revoked",
+      );
+    });
+
+    it("uses refreshed platform token on subsequent validation", async () => {
+      const { tokens } = await issueTokens(provider);
+
+      // First call: platform token expired, refresh succeeds
+      vi.mocked(axios.post).mockResolvedValueOnce({ data: { valid: false } });
+      vi.mocked(axios.post).mockResolvedValueOnce({
+        data: { access_token: "new-platform-token", refresh_token: "new-refresh" },
+      });
+
+      await provider.verifyAccessToken(tokens.access_token);
+
+      // Second call: should use cached validation (no platform call needed)
+      const authInfo = await provider.verifyAccessToken(tokens.access_token);
+      expect(authInfo.token).toBe(tokens.access_token);
+    });
+
+    it("getPlatformToken returns refreshed token after refresh", async () => {
+      const { tokens } = await issueTokens(provider);
+
+      // Original platform token
+      expect(await provider.getPlatformToken(tokens.access_token)).toBe("platform-token-123");
+
+      // Platform token expired, refresh succeeds
+      vi.mocked(axios.post).mockResolvedValueOnce({ data: { valid: false } });
+      vi.mocked(axios.post).mockResolvedValueOnce({
+        data: { access_token: "refreshed-platform-token", refresh_token: "new-refresh" },
+      });
+
+      await provider.verifyAccessToken(tokens.access_token);
+
+      // Should return the refreshed token
+      expect(await provider.getPlatformToken(tokens.access_token)).toBe("refreshed-platform-token");
     });
   });
 });


### PR DESCRIPTION
## Summary

- **Store platform refresh tokens** — `exchangeAuthorizationCode` now reads `refresh_token` from the platform's token exchange response and persists it in the `TokenRecord`
- **Auto-refresh expired platform tokens** — `verifyAccessToken` attempts `grant_type=refresh_token` against the platform before revoking, transparently extending sessions from 1 hour to 30 days
- **Security hardening** — sanitize Axios errors in logs to prevent `client_secret`/`refresh_token` leakage; add sensitive keys to log redaction set
- **Deduplicate refresh logic** — extract `attemptRefreshOrRevoke()` helper used by both `valid:false` and `401` code paths

Fixes ELN-513

> **Depends on**: Backend PR Elnora-AI/elnora-platform#676 (merged) which adds `grant_type=refresh_token` support to `/oauth/token`. Deploy backend first, then this PR.

## Test plan

- [x] TypeScript compiles clean (`tsc --noEmit`)
- [x] 111/111 unit tests pass (5 new: refresh on valid:false, refresh on 401, refresh failure → revoke, cached validation after refresh, getPlatformToken returns refreshed token)
- [x] Security audit: Axios error sanitization, log redaction, no credential leakage
- [ ] Deploy backend with refresh token support first
- [ ] Deploy this PR, authenticate, wait >1 hour, verify session survives

🤖 Generated with [Claude Code](https://claude.com/claude-code)