### PR TITLE
fix(ci): add GitHub issue cross-references to auto-fix PRs

### DIFF
--- a/.github/workflows/inspector-autofix.yml
+++ b/.github/workflows/inspector-autofix.yml
@@ -85,11 +85,17 @@ jobs:
               per_page: 100
             });
 
-            const existingIds = existingIssues.map(issue => {
+            const existingIds = [];
+            const vulnToIssueNumber = {};
+            for (const issue of existingIssues) {
               const cve = issue.title.match(/CVE-\d{4}-\d+/i);
               const ghsa = issue.title.match(/GHSA-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}/i);
-              return cve ? cve[0].toUpperCase() : (ghsa ? ghsa[0].toUpperCase() : null);
-            }).filter(Boolean);
+              const vid = cve ? cve[0].toUpperCase() : (ghsa ? ghsa[0].toUpperCase() : null);
+              if (vid) {
+                existingIds.push(vid);
+                vulnToIssueNumber[vid] = issue.number;
+              }
+            }
 
             const severityMap = { 'CRITICAL': 'Critical', 'HIGH': 'High', 'MEDIUM': 'Medium', 'LOW': 'Low' };
             const slaMap = { 'CRITICAL': '30 days', 'HIGH': '30 days', 'MEDIUM': '60 days', 'LOW': '90 days' };
@@ -118,7 +124,7 @@ jobs:
                 const sla = slaMap[severity] || '90 days';
 
                 try {
-                  await github.rest.issues.create({
+                  const { data: newIssue } = await github.rest.issues.create({
                     owner: context.repo.owner,
                     repo: context.repo.repo,
                     title: `[${severity}] ${vulnId}: ${title.substring(0, 80)}`,
@@ -147,8 +153,9 @@ jobs:
                     labels: ['Source: Vulnerability Scan', 'Flag: security', 'Repo: elnora-mcp-server',
                       `Severity: ${severityMap[severity] || 'Low'}`]
                   });
-                  console.log(`Created issue for ${vulnId}`);
+                  console.log(`Created issue #${newIssue.number} for ${vulnId}`);
                   existingIds.push(vulnId);
+                  vulnToIssueNumber[vulnId] = newIssue.number;
                 } catch (e) {
                   console.error(`Failed to create issue for ${vulnId}: ${e.message}`);
                 }
@@ -162,6 +169,7 @@ jobs:
                 fixedVersion: pkg?.fixedInVersion || null,
                 manager: pkg?.packageManager || 'OS',
                 title: finding.title || vulnId,
+                githubIssueNumber: vulnToIssueNumber[vulnId] || null,
                 description: (finding.description || '').substring(0, 500)
               });
             }
@@ -254,6 +262,11 @@ jobs:
             Include: Fixed table, Skipped table, Risk Assessment, and overall
             "ready-to-merge" or "needs-review" label. The description must be
             clear enough for a human reviewer to make a quick merge decision.
+
+            Also include a "Closes" section with `Fixes #NNN` for each fixed
+            vulnerability, using the `githubIssueNumber` from the findings data.
+            This auto-closes GitHub issues (and synced Linear issues) on merge.
+            Only include issue numbers for vulnerabilities actually fixed.
 
             ## Important Rules
 

--- a/.github/workflows/vuln-autofix.yml
+++ b/.github/workflows/vuln-autofix.yml
@@ -80,11 +80,18 @@ jobs:
               per_page: 100
             });
 
-            const existingIds = existingIssues.map(issue => {
+            // Build map of vuln ID → issue number for existing issues
+            const existingIds = [];
+            const vulnToIssueNumber = {};
+            for (const issue of existingIssues) {
               const cve = issue.title.match(/CVE-\d{4}-\d+/);
               const ghsa = issue.title.match(/GHSA-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}/);
-              return cve ? cve[0] : (ghsa ? ghsa[0] : null);
-            }).filter(Boolean);
+              const vulnId = cve ? cve[0] : (ghsa ? ghsa[0] : null);
+              if (vulnId) {
+                existingIds.push(vulnId);
+                vulnToIssueNumber[vulnId] = issue.number;
+              }
+            }
 
             // ── Create issues for new alerts + build summary for Claude ──
             const severityMap = { 'critical': 'Critical', 'high': 'High', 'medium': 'Medium', 'low': 'Low' };
@@ -110,7 +117,7 @@ jobs:
                 const sevLabel = `Severity: ${severityMap[severity] || 'Low'}`;
                 const sla = slaMap[severity] || '90 days';
                 try {
-                  await github.rest.issues.create({
+                  const { data: newIssue } = await github.rest.issues.create({
                     owner: context.repo.owner,
                     repo: context.repo.repo,
                     title: `[${severity.toUpperCase()}] ${id}: ${summary.substring(0, 80)}`,
@@ -139,17 +146,19 @@ jobs:
                     ].join('\n'),
                     labels: ['Source: Vulnerability Scan', 'Flag: security', 'Repo: elnora-mcp-server', sevLabel]
                   });
-                  console.log(`Created issue for ${id}`);
+                  console.log(`Created issue #${newIssue.number} for ${id}`);
                   existingIds.push(id);
+                  vulnToIssueNumber[id] = newIssue.number;
                 } catch (e) {
                   console.error(`Failed to create issue for ${id}: ${e.message}`);
                 }
               }
 
-              // Build summary object for Claude prompt
+              // Build summary object for Claude prompt (include issue number for PR cross-refs)
               alertSummaries.push({
                 id, severity, pkg, ecosystem, vulnRange, patchedVer, summary,
                 manifest, cvss,
+                githubIssueNumber: vulnToIssueNumber[id] || vulnToIssueNumber[cve] || vulnToIssueNumber[ghsa] || null,
                 description: description.substring(0, 500)
               });
             }
@@ -246,6 +255,17 @@ jobs:
 
                  ## Test Results
                  - Paste the test output summary
+
+                 ## Closes
+
+                 For each FIXED vulnerability, add a "Fixes #NNN" line using the
+                 `githubIssueNumber` field from the alert data. This auto-closes
+                 the GitHub issue (and its synced Linear issue) when the PR merges.
+                 Example:
+                 Fixes #117
+                 Fixes #118
+                 Only include issue numbers for vulnerabilities that were actually
+                 fixed in this PR — not for skipped ones.
 
                - Add label `security` to the PR
             6. If there are no fixable alerts (all are no-fix-available), do NOT create


### PR DESCRIPTION
## Summary

Auto-fix PRs now include `Fixes #NNN` references for each resolved vulnerability, which auto-closes the corresponding GitHub issues (and their synced Linear issues) when the PR is merged.

### Changes

- Track GitHub issue numbers when creating/finding vulnerability issues
- Pass `githubIssueNumber` field in the alert data JSON to Claude
- Instruct Claude to include a `Fixes #NNN` section in the PR body for each fixed vulnerability
- Applied to both `vuln-autofix.yml` and `inspector-autofix.yml`

### How it works

```
Detect step: CVE-2026-39410 → creates GitHub issue #117 → records mapping
Claude step: reads {id: "CVE-2026-39410", githubIssueNumber: 117, ...}
PR body:     includes "Fixes #117"
On merge:    GitHub auto-closes #117 → Linear auto-closes synced issue
```

## Test plan

- [ ] Merge this PR + merge the existing fix PR #131
- [ ] Trigger vuln-autofix again
- [ ] Verify new PR body contains `Fixes #NNN` references