### PR TITLE
fix(ci): add id-token permission for dep-batch-review OIDC auth

### DIFF
--- a/.github/workflows/dep-batch-review.yml
+++ b/.github/workflows/dep-batch-review.yml
@@ -15,6 +15,7 @@ permissions:
   contents: write
   pull-requests: write
   issues: write
+  id-token: write
 
 concurrency:
   group: dep-batch-review


### PR DESCRIPTION
## Summary

The dry-run test of dep-batch-review failed with:
```
Could not fetch an OIDC token. Did you remember to add id-token: write to your workflow permissions?
```

`anthropics/claude-code-action@v1` requires `id-token: write` for OIDC authentication with the Anthropic API. Same permission is present in `vuln-autofix.yml` and `inspector-autofix.yml` — was incorrectly omitted from the new workflow.

## Change

One line: add `id-token: write` to the `permissions:` block in `dep-batch-review.yml`.

## Test plan

- [ ] Merge this PR
- [ ] Re-run: `gh workflow run dep-batch-review.yml --repo Elnora-AI/elnora-mcp-server -f dry_run=true`
- [ ] Verify the Claude step starts successfully (no OIDC error)