### PR TITLE
chore(release): commit v1.0.0

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -3,8 +3,7 @@
     ".": {
       "release-type": "node",
       "package-name": "@elnora-ai/mcp-server",
-      "changelog-path": "CHANGELOG.md",
-      "bump-minor-pre-major": true
+      "changelog-path": "CHANGELOG.md"
     }
   }
 }


### PR DESCRIPTION
## Summary
- Removes \`bump-minor-pre-major\` from \`release-please-config.json\` so breaking-change commits bump the major version per SemVer.
- Commits the intentional v1.0.0 bump for the tool-surface work via a \`Release-As: 1.0.0\` footer.

## Why
The previous config caused release-please to cut v0.14.0 from #163 instead of v1.0.0. The tool-surface rename was deliberately marked breaking and we want a clean 1.0 signal.

## What happens after merge
Release-please will close the existing v0.14.0 PR (#165) and open a fresh PR targeting v1.0.0. Merging that PR creates the release and triggers deploy to \`mcp.elnora.ai\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)