### PR TITLE
chore(workflows): tighten auto-generated PR description format

### DIFF
--- a/.github/workflows/dep-batch-review.yml
+++ b/.github/workflows/dep-batch-review.yml
@@ -115,6 +115,30 @@ jobs:
             You are an automated dependency-update review agent for the
             Elnora MCP Server (TypeScript/Node.js, Express, MCP SDK, axios).
 
+            ## Public-Repository Disclosure Rules
+
+            This repository is PUBLIC. Individual Dependabot PRs, the batch
+            PR, sticky comments, and workflow logs are all visible to anyone
+            on the internet. Before writing any GitHub-visible text, ask
+            yourself whether it would help someone attack us.
+
+            Do NOT publish anywhere (PR body, commit message, comment, log):
+            - which files in our codebase import or use a given dependency
+            - which specific APIs/exports of a dependency our code calls
+            - CVE / advisory IDs with reasoning about whether they affect
+              our code paths (that analysis is an attack roadmap)
+            - attack preconditions, exploit paths, or threat reasoning
+            - defensive posture details about our runtime environment
+
+            For the "Codebase impact" line in sticky comments, emit only a
+            high-level count or Boolean-style note — never file paths,
+            function names, or API names. Examples of acceptable phrasings:
+            - "No direct imports; transitive only."
+            - "Direct import in a small number of internal modules."
+            - "Direct import; CI gates exercise the affected paths."
+            If you cannot describe the impact without naming files or APIs,
+            omit the line entirely.
+
             ## Your Task
 
             Read /tmp/dep-prs.json — a list of open Dependabot PRs. Review
@@ -175,10 +199,11 @@ jobs:
                **Package**: <name> (<old> → <new>)
 
                ### Rationale
-               - Changelog summary: <key entries>
-               - Codebase impact: <files using the package, affected APIs>
+               - Changelog summary: <key entries — public release notes only>
+               - Codebase impact: <high-level phrasing per public-repo rules,
+                 or omit entirely; never name files or APIs>
                - CI gates: lint ✓ / build ✓ / test ✓ (or specific failures; lint skipped if repo has no lint script)
-               - Transitive/peer notes: <if any>
+               - Transitive/peer notes: <if any — no CVE analysis>
 
                ### Recommendation
                <merge in the next batch PR | review manually before merging |

--- a/.github/workflows/inspector-autofix.yml
+++ b/.github/workflows/inspector-autofix.yml
@@ -213,6 +213,26 @@ jobs:
             You are an automated vulnerability remediation agent for container
             image vulnerabilities in the Elnora MCP Server.
 
+            ## Public-Repository Disclosure Rules
+
+            This repository is PUBLIC. Any text you put in a PR description,
+            commit message, issue comment, or stdout/workflow log is visible
+            to anyone on the internet. Treat all output as a public disclosure.
+
+            Do NOT publish, anywhere (PR body, commit message, comment, log):
+            - unfixed / skipped CVEs or any rationale for not fixing them
+            - risk-acceptance reasoning or "why this is safe despite not fixing"
+            - attack preconditions, threat analysis, or exploit-ability notes
+            - defensive posture details (what user the container runs as,
+              what syscalls/paths/capabilities are accessible, what packages
+              are or are not installed or invoked at runtime)
+            - any statement describing what conditions an attacker would need
+              or what conditions do not exist in our environment
+            - call-site or API usage details from our source code
+
+            If you need to reason about the above, keep it in your internal
+            scratchpad only — do not emit it to any GitHub-visible surface.
+
             ## Context
 
             This is a Node.js app running in a `node:24-slim` Docker image
@@ -223,49 +243,64 @@ jobs:
 
             ## Decision Framework
 
-            Container image vulnerabilities fall into two categories:
+            For each finding, classify as:
 
-            1. **OS package with fix available**: The fix comes from rebuilding
-               the Docker image with `--no-cache` to pull the latest base image
-               and packages. Check the Dockerfile — if it already uses the latest
-               `node:24-slim`, the fix depends on Debian publishing the patched
-               package. In that case, treat as "no fix yet".
+            1. **Fix available**: the base image can be updated to a newer tag,
+               or a specific OS package can be pinned/upgraded to the fixed
+               version in the Dockerfile. Apply the fix.
 
-            2. **OS package with no fix available**: These are risk acceptance
-               candidates. The container runs as non-root user `node`, doesn't
-               process untrusted packages, and doesn't mount filesystems. Most
-               OS-level vulns have attack preconditions that don't exist in this
-               container.
+            2. **No fix available**: skip silently. Do not modify code. Do not
+               produce any public analysis of these findings. The existing
+               open GitHub issue already tracks the finding; internal triage
+               happens there.
 
             ## Steps
 
             1. Read /tmp/inspector-findings.json
             2. Read the Dockerfile to understand the base image and build process
-            3. For each finding, determine if a fix is possible:
-               - If the base image can be updated to a newer tag, update it
-               - If OS packages can be pinned to fixed versions, add them to
-                 the Dockerfile
-               - If no fix exists, note it as risk acceptance candidate
+            3. For each finding, apply a fix if one is available per the
+               Decision Framework above. Skip the rest silently.
             4. If any Docker changes were made:
                - Run `npm run build` and `npm test` to verify the app still works
                - Create a branch `fix/container-vuln-remediation-<date>`
-               - Create a PR with a summary table of findings and actions taken
-            5. If all findings are no-fix-available:
+               - Create a PR (see PR Description Format below)
+            5. If no fixes were applied:
                - Do NOT create a PR
-               - Output a summary noting each finding and why it's a risk
-                 acceptance candidate (attack preconditions not present, package
-                 not used at runtime, etc.)
+               - Do NOT output risk-acceptance reasoning, skipped-CVE analysis,
+                 or attack-precondition notes. Exit quietly.
 
             ## PR Description Format
 
-            Include: Fixed table, Skipped table, Risk Assessment, and overall
-            "ready-to-merge" or "needs-review" label. The description must be
-            clear enough for a human reviewer to make a quick merge decision.
+            The PR description must describe only WHAT was fixed and HOW it
+            was verified. Required sections only:
 
-            Also include a "Closes" section with `Fixes #NNN` for each fixed
-            vulnerability, using the `githubIssueNumber` from the findings data.
-            This auto-closes GitHub issues (and synced Linear issues) on merge.
-            Only include issue numbers for vulnerabilities actually fixed.
+                 ## Summary
+                 One or two sentences naming the class of fix (e.g. "upgrade
+                 openssl to pick up the latest Debian security patch"). Do
+                 NOT summarize unfixed findings here.
+
+                 ## Fixed
+                 | CVE | Package | Severity | Fix Version | Action |
+                 |-----|---------|----------|-------------|--------|
+                 (FIXED CVEs only — one row each; no "Skipped" section)
+
+                 ## Changes
+                 One-line description per changed file.
+
+                 ## Test Plan
+                 - [x] `npm run build` — result
+                 - [x] `npm test` — result (e.g. "122 tests pass, 0 failures")
+
+                 Fixes #NNN
+                 Fixes #MMM
+                 (one "Fixes #NNN" line per FIXED CVE, using the
+                 `githubIssueNumber` from the findings data; no lines for
+                 skipped CVEs)
+
+            Do NOT include: "Skipped", "Risk Assessment", "Closes" as a
+            heading, "ready-to-merge" / "needs-review" labels in the body,
+            or any narrative about the container runtime, user, filesystem,
+            or syscall surface.
 
             ## Important Rules
 

--- a/.github/workflows/vuln-autofix.yml
+++ b/.github/workflows/vuln-autofix.yml
@@ -196,6 +196,25 @@ jobs:
             You are an automated vulnerability remediation agent for the Elnora
             MCP Server (a TypeScript/Node.js project using Express, MCP SDK, axios).
 
+            ## Public-Repository Disclosure Rules
+
+            This repository is PUBLIC. Any text you put in a PR description,
+            commit message, issue comment, or stdout/workflow log is visible
+            to anyone on the internet. Treat all output as a public disclosure.
+
+            Do NOT publish, anywhere (PR body, commit message, comment, log):
+            - unfixed / skipped CVEs or any rationale for not fixing them
+            - risk-acceptance reasoning or "why this is safe despite not fixing"
+            - attack preconditions, threat analysis, or exploit-ability notes
+            - defensive posture details (container user, runtime surface, etc.)
+            - any statement describing what conditions an attacker would need
+              or what conditions do not exist in our environment
+            - which call sites or files import the vulnerable dependency, or
+              which APIs of that dependency our code uses
+
+            If you need to reason about the above, keep it in your internal
+            scratchpad only — do not emit it to any GitHub-visible surface.
+
             ## Your Task
 
             Read /tmp/vuln-alerts.json which contains open Dependabot vulnerability
@@ -214,15 +233,13 @@ jobs:
             2. **Fix available (major version bump)**:
                - Check the package changelog/release notes for breaking changes.
                - If the package is a devDependency (only used in tests/build), apply it.
-               - If it's a production dependency, check if our code uses any APIs that
-                 changed. Apply if safe, skip if breaking.
-               - Note any skipped major bumps in your report.
+               - If it's a production dependency, assess internally whether it's
+                 safe to apply. Apply if safe, skip silently if not.
 
             3. **No fix available**:
                - Do NOT modify any code for these.
-               - Note them in your report as "no fix available — risk acceptance candidate".
-               - Include a brief explanation of why the risk is acceptable (e.g., the
-                 vulnerable code path is not reachable in our deployment).
+               - Do NOT produce public analysis or rationale. The existing open
+                 GitHub issue already tracks the alert for internal triage.
 
             ## Steps
 
@@ -232,43 +249,35 @@ jobs:
                a. Apply the fix (update package.json or overrides)
                b. Run `npm install` to update the lockfile
                c. Run `npm test` to verify nothing breaks
-               d. If tests fail, revert that specific change and note it as "fix broke tests"
+               d. If tests fail, revert that specific change silently.
             4. After all fixes are applied, run `npm audit` to verify remaining status
             5. Create a single branch and PR with all fixes:
                - Branch: `fix/vuln-remediation-<date>` (use today's date, e.g., fix/vuln-remediation-2026-04-08)
                - PR title: `fix(deps): automated vulnerability remediation <date>`
-               - PR body must include:
+               - PR body must include ONLY the sections below:
 
                  ## Vulnerabilities Fixed
                  | CVE/GHSA | Package | Old Version | New Version | Type |
                  |----------|---------|-------------|-------------|------|
-                 (table of all fixed vulns)
-
-                 ## Vulnerabilities Skipped
-                 | CVE/GHSA | Package | Reason |
-                 |----------|---------|--------|
-                 (table of skipped vulns with reasons)
-
-                 ## Risk Assessment
-                 - For each fix: brief note on safety (patch/minor, tests pass, etc.)
-                 - Overall assessment: "ready-to-merge" or "needs-review"
+                 (FIXED vulns only — no "Skipped", no "Risk Assessment",
+                  no safety commentary)
 
                  ## Test Results
-                 - Paste the test output summary
+                 One line summary only (e.g. "122 tests pass, 0 failures").
+                 Do NOT paste stack traces or error details.
 
-                 ## Closes
+                 Fixes #NNN
+                 Fixes #MMM
+                 (one "Fixes #NNN" line per FIXED vuln, using the
+                 `githubIssueNumber` from the alert data; no lines for
+                 skipped or unfixed vulns)
 
-                 For each FIXED vulnerability, add a "Fixes #NNN" line using the
-                 `githubIssueNumber` field from the alert data. This auto-closes
-                 the GitHub issue (and its synced Linear issue) when the PR merges.
-                 Example:
-                 Fixes #117
-                 Fixes #118
-                 Only include issue numbers for vulnerabilities that were actually
-                 fixed in this PR — not for skipped ones.
+               Do NOT include these sections: "Vulnerabilities Skipped",
+               "Risk Assessment", "ready-to-merge" / "needs-review" labels,
+               or any narrative about impact on our codebase.
 
-            6. If there are no fixable alerts (all are no-fix-available), do NOT create
-               a PR. Instead, just output a summary of what was found.
+            6. If there are no fixable alerts, do NOT create a PR and do NOT
+               emit a public summary of what was found. Exit quietly.
 
             ## Important Rules
 
@@ -281,8 +290,9 @@ jobs:
             - When creating the PR, request a review from `rjamul-elnora-ai`
               using `gh pr create ... --reviewer rjamul-elnora-ai`. This ensures
               the PR author gets a GitHub notification to review the auto-fix.
-            - The PR description must be clear enough for a human reviewer to
-              understand what changed and why, and to make a merge decision quickly.
+            - The PR description must be clear enough for a reviewer to decide
+              on merge, but it must not include any of the items forbidden in
+              the Public-Repository Disclosure Rules above.
           claude_args: |
             --model claude-sonnet-4-6
             --max-turns 60


### PR DESCRIPTION
## Summary

Updates prompt templates used by the three auto-generated PR workflows (`inspector-autofix`, `vuln-autofix`, `dep-batch-review`) so generated PR bodies and per-PR sticky comments follow a narrower section list. No change to workflow triggers, steps, or permissions.

## Test Plan

- [x] All three workflow files parse as valid YAML.
- [ ] Verify on the next scheduled run that generated PR bodies follow the new template.