### PR TITLE
chore: add SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,15 @@
+# Security Policy
+
+Thank you for helping keep elnora-mcp-server secure.
+
+## Reporting a vulnerability
+
+If you believe you've found a security vulnerability in this repository, please report it privately. **Do not** open a public issue or pull request describing the vulnerability.
+
+Use GitHub's **Report a vulnerability** button on this repository's [Security tab](https://github.com/Elnora-AI/elnora-mcp-server/security). It opens a private report visible only to the maintainers.
+
+We will acknowledge your report and coordinate a fix and disclosure with you through GitHub's [security advisory](https://docs.github.com/en/code-security/security-advisories) flow.
+
+## Scope
+
+Both code-level vulnerabilities in this repository and dependency vulnerabilities affecting the published package are in scope.


### PR DESCRIPTION
## Summary
Adds a top-level `SECURITY.md` routing external researchers to GitHub's 'Report a vulnerability' button (Private Vulnerability Reporting) on the Security tab.

## Test plan
- [ ] Verify Security tab shows the new policy
- [ ] Confirm Private Vulnerability Reporting is enabled in repo settings (Settings → Code security and analysis)