### PR TITLE
fix(docker): bump base to debian 13 + refresh deps

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:24-slim AS builder
+FROM node:24-trixie-slim AS builder
 WORKDIR /app
 RUN apt-get update && \
     apt-get upgrade -y --no-install-recommends && \
@@ -10,7 +10,7 @@ COPY tsconfig.json ./
 COPY src/ ./src/
 RUN npm run build
 
-FROM node:24-slim
+FROM node:24-trixie-slim
 WORKDIR /app
 ENV NODE_ENV=production
 RUN apt-get update && \

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@modelcontextprotocol/sdk": "^1.29.0",
         "axios": "^1.15.2",
         "express": "^5.1.0",
-        "express-rate-limit": "^8.4.1",
+        "express-rate-limit": "^8.5.0",
         "ioredis": "^5.10.0",
         "zod": "^4.4.1"
       },
@@ -690,9 +690,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -710,9 +707,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -730,9 +724,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -750,9 +741,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -770,9 +758,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -790,9 +775,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1654,12 +1636,12 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "8.4.1",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.4.1.tgz",
-      "integrity": "sha512-NGVYwQSAyEQgzxX1iCM978PP9AdO/hW93gMcF6ZwQCm+rFvLsBH6w4xcXWTcliS8La5EPRN3p9wzItqBwJrfNw==",
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.1.tgz",
+      "integrity": "sha512-5O6KYmyJEpuPJV5hNTXKbAHWRqrzyu+OI3vUnSd2kXFubIVpG7ezpgxQy76Zo5GQZtrQBg86hF+CM/NX+cioiQ==",
       "license": "MIT",
       "dependencies": {
-        "ip-address": "10.1.0"
+        "ip-address": "^10.2.0"
       },
       "engines": {
         "node": ">= 16"
@@ -2008,9 +1990,9 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
-      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -2201,9 +2183,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2225,9 +2204,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2249,9 +2225,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2273,9 +2246,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@modelcontextprotocol/sdk": "^1.29.0",
     "axios": "^1.15.2",
     "express": "^5.1.0",
-    "express-rate-limit": "^8.4.1",
+    "express-rate-limit": "^8.5.0",
     "ioredis": "^5.10.0",
     "zod": "^4.4.1"
   },


### PR DESCRIPTION
## Summary

- Dockerfile (both stages): `node:24-slim` → `node:24-trixie-slim`. Same Node 24.15.0 runtime, newer Debian 13 base OS package set.
- `express-rate-limit ^8.4.1` → `^8.5.0`. Lock resolves to 8.5.1; transitive `ip-address` refreshes to 10.2.0.

## Verification

- `npm install`: 0 audit issues, 41 packages updated
- `npm run build`: clean (tsc)
- `npm test`: 122 passed, 32 skipped, 0 failed (vitest, 13 files)
- `docker build`: clean
- Container smoke: \`node -v\` = 24.15.0, base = Debian 13.4

## Test plan

- [ ] CI build + tests pass on this branch
- [ ] Production rollout via release-please bump

Closes SEC-338
Closes SEC-397
Closes SEC-432
Closes SEC-433
Closes SEC-434
Closes SEC-444

🤖 Generated with [Claude Code](https://claude.com/claude-code)