### PR TITLE
fix(orgs): use stripeCustomerId in set-stripe wire payload

### DIFF
--- a/src/tools/orgs.ts
+++ b/src/tools/orgs.ts
@@ -230,15 +230,15 @@ export function registerOrgTools(
       description: "Set the Stripe customer ID for an organization",
       inputSchema: {
         orgId: z.string().uuid().describe("Organization UUID"),
-        customerId: z.string().min(1).describe("Stripe customer ID"),
+        stripeCustomerId: z.string().min(1).describe("Stripe customer ID"),
 
         ...OUTPUT_OPTIONS_SCHEMA,
       },
       annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: true, openWorldHint: true },
     },
-    withGuard("elnora_orgs_setStripe", getContext, async ({ orgId, customerId }) => {
+    withGuard("elnora_orgs_setStripe", getContext, async ({ orgId, stripeCustomerId }) => {
       try {
-        const result = await getClient().put(`/organizations/${orgId}/stripe-customer`, { customerId });
+        const result = await getClient().put(`/organizations/${orgId}/stripe-customer`, { stripeCustomerId });
         return { content: [{ type: "text" as const, text: JSON.stringify(result) }] };
       } catch (error) {
         return { content: [{ type: "text" as const, text: handleApiError(error) }], isError: true };


### PR DESCRIPTION
## Summary

The `elnora_orgs_setStripe` MCP tool was sending the Stripe customer ID under the wrong field name in the request payload. The API silently ignored the unknown field, which left the underlying value unset — clearing any previously-stored value rather than updating it.

## Change

- Parameter renamed: `customerId` → `stripeCustomerId` so the input schema and the wire payload key both match the API contract.
- Wire payload key fixed accordingly.

## Companion change

This is the matching fix for the same field-name issue in `elnora-cli` (https://github.com/Elnora-AI/elnora-cli/pull/146). The two repos share a tool surface that the MCP-parity audit (`scripts/audit-mcp-parity.ts`) enforces on every CLI PR. Both definitions must update together. **Merge this first so the CLI PR's parity check goes green.**

## Test plan

- [x] `npm run build` clean (tsc)
- [x] `npm test` — all tests pass