### PR TITLE
chore(ci): publish to npm via OIDC trusted publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,5 +28,3 @@ jobs:
       - run: npm run build
       - run: npm test
       - run: npm publish --access public --provenance
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Use npm's [Trusted Publishing](https://docs.npmjs.com/trusted-publishers) (GitHub Actions OIDC) for `npm publish`.

Trusted Publisher already configured on the npm package side.