### PR TITLE
fix(docker): bump base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:24-trixie-slim AS builder
+FROM node:24.16.0-trixie-slim AS builder
 WORKDIR /app
 RUN apt-get update && \
     apt-get upgrade -y --no-install-recommends && \
@@ -10,7 +10,7 @@ COPY tsconfig.json ./
 COPY src/ ./src/
 RUN npm run build
 
-FROM node:24-trixie-slim
+FROM node:24.16.0-trixie-slim
 WORKDIR /app
 ENV NODE_ENV=production
 RUN apt-get update && \


### PR DESCRIPTION
Bumps the container base image.

Closes SEC-646
Closes SEC-647
Closes SEC-648
Closes SEC-649
Closes SEC-650
Closes SEC-651
Closes SEC-652
Closes SEC-653
Closes SEC-654
Closes SEC-655
Closes SEC-656
Closes SEC-657
Closes SEC-658
Closes SEC-659
Closes SEC-660