### PR TITLE
fix: correct wrong API routes and verb in account/orgs tools

### DIFF
--- a/src/tools/account.ts
+++ b/src/tools/account.ts
@@ -122,7 +122,7 @@ export function registerAccountTools(
         if (!yes) {
           return { content: [{ type: "text" as const, text: "Error: Account deletion requires yes=true to confirm." }], isError: true };
         }
-        await getClient().del("/account");
+        await getClient().del("/account/me");
         return { content: [{ type: "text" as const, text: JSON.stringify({ deleted: true }) }] };
       } catch (error) {
         return { content: [{ type: "text" as const, text: handleApiError(error) }], isError: true };
@@ -148,7 +148,7 @@ export function registerAccountTools(
         const query: Record<string, string> = {};
         if (state) query.state = state;
         if (refCode) query.refCode = refCode;
-        const result = await getClient().get("/account/users", Object.keys(query).length > 0 ? query : undefined);
+        const result = await getClient().get("/account/user/list", Object.keys(query).length > 0 ? query : undefined);
         return { content: [{ type: "text" as const, text: JSON.stringify(result) }] };
       } catch (error) {
         return { content: [{ type: "text" as const, text: handleApiError(error) }], isError: true };
@@ -175,7 +175,7 @@ export function registerAccountTools(
       try {
         const body: Record<string, string> = { documentType, version, content };
         if (effectiveDate) body.effectiveDate = effectiveDate;
-        const result = await getClient().post("/legal-docs/versions", body);
+        const result = await getClient().post("/userAgreement/legalDocumentVersion", body);
         return { content: [{ type: "text" as const, text: JSON.stringify(result) }] };
       } catch (error) {
         return { content: [{ type: "text" as const, text: handleApiError(error) }], isError: true };
@@ -205,7 +205,7 @@ export function registerAccountTools(
         if (Object.keys(body).length === 0) {
           return { content: [{ type: "text" as const, text: "Error: At least one of content or effectiveDate is required." }], isError: true };
         }
-        const result = await getClient().patch(`/legal-docs/versions/${versionId}`, body);
+        const result = await getClient().put(`/userAgreement/legalDocumentVersion/${versionId}`, body);
         return { content: [{ type: "text" as const, text: JSON.stringify(result) }] };
       } catch (error) {
         return { content: [{ type: "text" as const, text: handleApiError(error) }], isError: true };
@@ -231,7 +231,7 @@ export function registerAccountTools(
         if (!yes) {
           return { content: [{ type: "text" as const, text: "Error: Legal doc deletion requires yes=true to confirm." }], isError: true };
         }
-        await getClient().del(`/legal-docs/versions/${versionId}`);
+        await getClient().del(`/userAgreement/legalDocumentVersion/${versionId}`);
         return { content: [{ type: "text" as const, text: JSON.stringify({ deleted: true, versionId }) }] };
       } catch (error) {
         return { content: [{ type: "text" as const, text: handleApiError(error) }], isError: true };

--- a/src/tools/orgs.ts
+++ b/src/tools/orgs.ts
@@ -260,7 +260,7 @@ export function registerOrgTools(
     },
     withGuard("elnora_orgs_setDefault", getContext, async ({ orgId }) => {
       try {
-        const result = await getClient().put(`/organizations/${orgId}/default`);
+        const result = await getClient().put(`/organizations/${orgId}/set-default`);
         return { content: [{ type: "text" as const, text: JSON.stringify(result) }] };
       } catch (error) {
         return { content: [{ type: "text" as const, text: handleApiError(error) }], isError: true };
@@ -440,7 +440,7 @@ export function registerOrgTools(
     },
     withGuard("elnora_orgs_listAll", getContext, async () => {
       try {
-        const result = await getClient().get("/admin/organizations");
+        const result = await getClient().get("/organizations/all");
         return { content: [{ type: "text" as const, text: JSON.stringify(result) }] };
       } catch (error) {
         return { content: [{ type: "text" as const, text: handleApiError(error) }], isError: true };

--- a/tests/tools/route-corrections.test.ts
+++ b/tests/tools/route-corrections.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect, vi } from "vitest";
+import { createElnoraServer, RequestContext } from "../../src/server.js";
+import { ALL_SCOPES } from "../../src/constants.js";
+import type { ElnoraApiClient } from "../../src/services/elnora-api-client.js";
+
+// Regression guard for the route corrections: several tools previously called
+// non-existent backend routes (404) or the wrong HTTP verb (405). These tests
+// invoke each fixed tool's handler with a spy client and assert the exact
+// path/method it calls, so the drift can't silently return.
+
+function makeServerWithSpyClient() {
+  const client = {
+    get: vi.fn().mockResolvedValue({}),
+    post: vi.fn().mockResolvedValue({}),
+    put: vi.fn().mockResolvedValue({}),
+    patch: vi.fn().mockResolvedValue({}),
+    del: vi.fn().mockResolvedValue({}),
+  } as unknown as ElnoraApiClient;
+  const ctx: RequestContext = { client, clientId: "test", scopes: ALL_SCOPES };
+  const server = createElnoraServer(() => ctx);
+  const tools = (server as unknown as { _registeredTools: Record<string, { handler: (args: unknown, extra: unknown) => unknown }> })._registeredTools;
+  const invoke = (name: string, args: Record<string, unknown>) => tools[name].handler(args, {});
+  return { client, invoke };
+}
+
+const ORG_ID = "d1ff6d88-f3e6-465e-b1d6-89cd840b1dc5";
+const VERSION_ID = "abc-123";
+
+describe("route corrections (regression for 404/405 tool bugs)", () => {
+  it("elnora_orgs_setDefault → PUT /organizations/{id}/set-default", async () => {
+    const { client, invoke } = makeServerWithSpyClient();
+    await invoke("elnora_orgs_setDefault", { orgId: ORG_ID });
+    expect(client.put).toHaveBeenCalledWith(`/organizations/${ORG_ID}/set-default`);
+  });
+
+  it("elnora_orgs_listAll → GET /organizations/all", async () => {
+    const { client, invoke } = makeServerWithSpyClient();
+    await invoke("elnora_orgs_listAll", {});
+    expect(client.get).toHaveBeenCalledWith("/organizations/all");
+  });
+
+  it("elnora_account_delete → DELETE /account/me", async () => {
+    const { client, invoke } = makeServerWithSpyClient();
+    await invoke("elnora_account_delete", { yes: true });
+    expect(client.del).toHaveBeenCalledWith("/account/me");
+  });
+
+  it("elnora_account_users → GET /account/user/list", async () => {
+    const { client, invoke } = makeServerWithSpyClient();
+    await invoke("elnora_account_users", {});
+    expect((client.get as unknown as { mock: { calls: unknown[][] } }).mock.calls[0][0]).toBe("/account/user/list");
+  });
+
+  it("elnora_account_addLegalDoc → POST /userAgreement/legalDocumentVersion", async () => {
+    const { client, invoke } = makeServerWithSpyClient();
+    await invoke("elnora_account_addLegalDoc", { documentType: "tos", version: "1", content: "x" });
+    expect((client.post as unknown as { mock: { calls: unknown[][] } }).mock.calls[0][0]).toBe("/userAgreement/legalDocumentVersion");
+  });
+
+  it("elnora_account_updateLegalDoc → PUT /userAgreement/legalDocumentVersion/{id} (not PATCH)", async () => {
+    const { client, invoke } = makeServerWithSpyClient();
+    await invoke("elnora_account_updateLegalDoc", { versionId: VERSION_ID, content: "x" });
+    expect((client.put as unknown as { mock: { calls: unknown[][] } }).mock.calls[0][0]).toBe(`/userAgreement/legalDocumentVersion/${VERSION_ID}`);
+    expect(client.patch).not.toHaveBeenCalled();
+  });
+
+  it("elnora_account_deleteLegalDoc → DELETE /userAgreement/legalDocumentVersion/{id}", async () => {
+    const { client, invoke } = makeServerWithSpyClient();
+    await invoke("elnora_account_deleteLegalDoc", { versionId: VERSION_ID, yes: true });
+    expect(client.del).toHaveBeenCalledWith(`/userAgreement/legalDocumentVersion/${VERSION_ID}`);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes several tools that called routes/verbs the API doesn't expose, so they failed at runtime (404/405).
These were nominally "covered" but broken.

| Tool | Was | Now |
|---|---|---|
| `elnora_orgs_setDefault` | `PUT …/{id}/default` | `…/set-default` |
| `elnora_orgs_listAll` | `GET /admin/organizations` | `/organizations/all` |
| `elnora_account_delete` | `DELETE /account` | `/account/me` |
| `elnora_account_users` | `GET /account/users` | `/account/user/list` |
| legal-doc add/update/delete | `/legal-docs/versions` | `/userAgreement/legalDocumentVersion` |
| legal-doc update | `PATCH` | `PUT` |

Adds a regression test that invokes each fixed handler with a spy client and asserts the exact path/method,
so the drift can't silently return. Build + tests green (129 pass).
