### PR TITLE
fix(docs): exclude staff-only tools from the public MCP catalog

### DIFF
--- a/scripts/gen-docs-reference.ts
+++ b/scripts/gen-docs-reference.ts
@@ -107,6 +107,37 @@ for (const [cat, fn] of REGISTRATIONS) {
 }
 
 // ---------------------------------------------------------------------------
+// exclude staff-only tools from the PUBLIC catalog
+// ---------------------------------------------------------------------------
+// docs.elnora.ai is public. A handful of tools are SystemAdmin/staff-only (they
+// still work on the server for admins — this only stops them being *documented*).
+// We filter by the same markers the docs safety-scan enforces, so the generated
+// catalog can never trip the publish gate: an explicit name denylist (intent)
+// plus the "(admin)" / "SystemAdmin" description convention (auto-covers any new
+// staff-only tool that follows the same convention). The ToolAnnotations type is
+// a closed zod object, so a per-tool `internal` annotation isn't an option — the
+// docs generator is the right layer for this docs-publishing policy.
+const INTERNAL_TOOL_NAMES = new Set([
+	"elnora_account_users",
+	"elnora_account_addLegalDoc",
+	"elnora_account_updateLegalDoc",
+	"elnora_account_deleteLegalDoc",
+	"elnora_orgs_listAll",
+]);
+function isInternalTool(t: Captured): boolean {
+	if (INTERNAL_TOOL_NAMES.has(t.name)) return true;
+	const desc = t.config.description ?? "";
+	return /\bSystemAdmin\b/.test(desc) || /\(admin\)/i.test(desc);
+}
+const excluded = tools.filter(isInternalTool).map((t) => t.name);
+for (let i = tools.length - 1; i >= 0; i--) {
+	if (isInternalTool(tools[i])) tools.splice(i, 1);
+}
+if (excluded.length) {
+	console.log(`Excluded ${excluded.length} staff-only tool(s) from the public catalog: ${excluded.join(", ")}`);
+}
+
+// ---------------------------------------------------------------------------
 // helpers (MDX + table safe) — mirror the CLI generator
 // ---------------------------------------------------------------------------
 function inlineText(s: string | undefined): string {


### PR DESCRIPTION
## Summary
The public docs.elnora.ai MCP catalog generator emitted **every** registered tool — including five SystemAdmin/staff-only ones:
- `elnora_account_users` ("List all users (admin)")
- `elnora_account_addLegalDoc` / `updateLegalDoc` / `deleteLegalDoc` ("… (SystemAdmin only)")
- `elnora_orgs_listAll` ("List all organizations (admin)")

Their `(admin)` / `SystemAdmin` descriptions trip the docs repo's publish **safety scan**, so the self-maintaining `docs-sync` lane failed on every run and no reference PR could open.

## Fix
Filter these out in `scripts/gen-docs-reference.ts` by the same markers the docs safety scan enforces — an explicit name denylist (intent) **plus** the `(admin)` / `SystemAdmin` description convention, so any new staff-only tool following the convention is auto-excluded. The generator logs what it drops (no silent filtering).

The tools **still work on the server** for admins — this only stops them being *documented* publicly. `ToolAnnotations` is a closed zod object, so a per-tool `internal` annotation isn't typeable; the docs generator is the correct layer for a docs-publishing policy.

## Verification
- Generator excludes exactly 5 tools; output has **zero** `SystemAdmin` / `(admin)` markers; 85 public tools / 14 categories remain.
- `npm run build` (tsc) ✓, `tsc -p tsconfig.test.json --noEmit` ✓, `npm test` = 122 passed / 32 skipped ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q3VN8ziojcccGj1MonB49s