### PR TITLE
feat(folders): add Knowledge Base folder read tools

### DIFF
--- a/src/tools/folders.ts
+++ b/src/tools/folders.ts
@@ -12,6 +12,94 @@ export function registerFolderTools(
   getContext: () => RequestContext,
 ): void {
   server.registerTool(
+    "elnora_folders_roots",
+    {
+      title: "elnora_folders_roots",
+      description: "List the top-level Knowledge Base folders you can access",
+      inputSchema: {
+        ...OUTPUT_OPTIONS_SCHEMA,
+      },
+      annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: true },
+    },
+    withGuard("elnora_folders_roots", getContext, async () => {
+      try {
+        const result = await getClient().get("/folders/roots");
+        return { content: [{ type: "text" as const, text: JSON.stringify(result) }] };
+      } catch (error) {
+        return { content: [{ type: "text" as const, text: handleApiError(error) }], isError: true };
+      }
+    }),
+  );
+
+  server.registerTool(
+    "elnora_folders_children",
+    {
+      title: "elnora_folders_children",
+      description: "List the child folders of a Knowledge Base folder",
+      inputSchema: {
+        folderId: z.string().uuid().describe("Folder UUID"),
+
+        ...OUTPUT_OPTIONS_SCHEMA,
+      },
+      annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: true },
+    },
+    withGuard("elnora_folders_children", getContext, async ({ folderId }) => {
+      try {
+        const result = await getClient().get(`/folders/${folderId}/children`);
+        return { content: [{ type: "text" as const, text: JSON.stringify(result) }] };
+      } catch (error) {
+        return { content: [{ type: "text" as const, text: handleApiError(error) }], isError: true };
+      }
+    }),
+  );
+
+  server.registerTool(
+    "elnora_folders_get",
+    {
+      title: "elnora_folders_get",
+      description: "Get a Knowledge Base folder's details and breadcrumb path",
+      inputSchema: {
+        folderId: z.string().uuid().describe("Folder UUID"),
+
+        ...OUTPUT_OPTIONS_SCHEMA,
+      },
+      annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: true },
+    },
+    withGuard("elnora_folders_get", getContext, async ({ folderId }) => {
+      try {
+        const result = await getClient().get(`/folders/${folderId}`);
+        return { content: [{ type: "text" as const, text: JSON.stringify(result) }] };
+      } catch (error) {
+        return { content: [{ type: "text" as const, text: handleApiError(error) }], isError: true };
+      }
+    }),
+  );
+
+  server.registerTool(
+    "elnora_folders_files",
+    {
+      title: "elnora_folders_files",
+      description: "List files placed directly in a Knowledge Base folder",
+      inputSchema: {
+        folderId: z.string().uuid().describe("Folder UUID"),
+        page: z.number().int().min(1).default(1).describe("Page number"),
+        pageSize: z.number().int().min(1).max(100).default(25).describe("Results per page"),
+
+        ...OUTPUT_OPTIONS_SCHEMA,
+      },
+      annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: true },
+    },
+    withGuard("elnora_folders_files", getContext, async ({ folderId, page, pageSize }) => {
+      try {
+        const result = await getClient().get(`/folders/${folderId}/files`, { page, pageSize });
+        return { content: [{ type: "text" as const, text: JSON.stringify(result) }] };
+      } catch (error) {
+        return { content: [{ type: "text" as const, text: handleApiError(error) }], isError: true };
+      }
+    }),
+  );
+
+  server.registerTool(
     "elnora_folders_list",
     {
       title: "elnora_folders_list",

--- a/src/tools/scope-guard.ts
+++ b/src/tools/scope-guard.ts
@@ -72,6 +72,10 @@ export const TOOL_SCOPES: Record<string, string[]> = {
   elnora_orgs_listAll: ["orgs:read"],
 
   // Folders
+  elnora_folders_roots: ["folders:read"],
+  elnora_folders_children: ["folders:read"],
+  elnora_folders_get: ["folders:read"],
+  elnora_folders_files: ["folders:read"],
   elnora_folders_list: ["folders:read"],
   elnora_folders_create: ["folders:write"],
   elnora_folders_rename: ["folders:write"],

--- a/tests/tools/folders-kb.test.ts
+++ b/tests/tools/folders-kb.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect, vi } from "vitest";
+import { createElnoraServer, RequestContext } from "../../src/server.js";
+import { ALL_SCOPES } from "../../src/constants.js";
+import type { ElnoraApiClient } from "../../src/services/elnora-api-client.js";
+
+// The Knowledge Base folder read tools (roots/children/get/files) must call the
+// closure-table controller paths, not the legacy project-scoped ones.
+
+function makeServerWithSpyClient() {
+  const client = {
+    get: vi.fn().mockResolvedValue({}),
+    post: vi.fn().mockResolvedValue({}),
+    put: vi.fn().mockResolvedValue({}),
+    patch: vi.fn().mockResolvedValue({}),
+    del: vi.fn().mockResolvedValue({}),
+  } as unknown as ElnoraApiClient;
+  const ctx: RequestContext = { client, clientId: "test", scopes: ALL_SCOPES };
+  const server = createElnoraServer(() => ctx);
+  const tools = (server as unknown as { _registeredTools: Record<string, { handler: (args: unknown, extra: unknown) => unknown }> })._registeredTools;
+  const invoke = (name: string, args: Record<string, unknown>) => tools[name].handler(args, {});
+  return { client, invoke };
+}
+
+const FOLDER_ID = "d5c4b3a2-f6e5-4b7a-9d8c-1f0e2a3b4c5d";
+
+describe("KB folder read tools", () => {
+  it("elnora_folders_roots → GET /folders/roots", async () => {
+    const { client, invoke } = makeServerWithSpyClient();
+    await invoke("elnora_folders_roots", {});
+    expect(client.get).toHaveBeenCalledWith("/folders/roots");
+  });
+
+  it("elnora_folders_children → GET /folders/{id}/children", async () => {
+    const { client, invoke } = makeServerWithSpyClient();
+    await invoke("elnora_folders_children", { folderId: FOLDER_ID });
+    expect(client.get).toHaveBeenCalledWith(`/folders/${FOLDER_ID}/children`);
+  });
+
+  it("elnora_folders_get → GET /folders/{id}", async () => {
+    const { client, invoke } = makeServerWithSpyClient();
+    await invoke("elnora_folders_get", { folderId: FOLDER_ID });
+    expect(client.get).toHaveBeenCalledWith(`/folders/${FOLDER_ID}`);
+  });
+
+  it("elnora_folders_files → GET /folders/{id}/files with pagination", async () => {
+    const { client, invoke } = makeServerWithSpyClient();
+    await invoke("elnora_folders_files", { folderId: FOLDER_ID, page: 1, pageSize: 25 });
+    expect(client.get).toHaveBeenCalledWith(`/folders/${FOLDER_ID}/files`, { page: 1, pageSize: 25 });
+  });
+});

--- a/tests/tools/tool-registration.test.ts
+++ b/tests/tools/tool-registration.test.ts
@@ -46,7 +46,7 @@ describe("Tool Registration", () => {
       projects: ["elnora_projects_list", "elnora_projects_get", "elnora_projects_create", "elnora_projects_update", "elnora_projects_archive", "elnora_projects_members", "elnora_projects_addMember", "elnora_projects_updateRole", "elnora_projects_removeMember", "elnora_projects_leave"],
       search: ["elnora_search_tasks", "elnora_search_files", "elnora_search_all", "elnora_search_fileContent"],
       orgs: ["elnora_orgs_list", "elnora_orgs_get", "elnora_orgs_create", "elnora_orgs_update", "elnora_orgs_delete", "elnora_orgs_members", "elnora_orgs_updateRole", "elnora_orgs_removeMember", "elnora_orgs_billing", "elnora_orgs_setStripe", "elnora_orgs_setDefault", "elnora_orgs_invite", "elnora_orgs_invitations", "elnora_orgs_cancelInvite", "elnora_orgs_resendInvite", "elnora_orgs_invitationInfo", "elnora_orgs_acceptInvite", "elnora_orgs_files", "elnora_orgs_listAll"],
-      folders: ["elnora_folders_list", "elnora_folders_create", "elnora_folders_rename", "elnora_folders_move", "elnora_folders_delete"],
+      folders: ["elnora_folders_roots", "elnora_folders_children", "elnora_folders_get", "elnora_folders_files", "elnora_folders_list", "elnora_folders_create", "elnora_folders_rename", "elnora_folders_move", "elnora_folders_delete"],
       library: ["elnora_library_files", "elnora_library_folders", "elnora_library_createFolder", "elnora_library_renameFolder", "elnora_library_deleteFolder"],
       apiKeys: ["elnora_api-keys_list", "elnora_api-keys_create", "elnora_api-keys_revoke", "elnora_api-keys_getPolicy", "elnora_api-keys_setPolicy"],
       audit: ["elnora_audit_list"],


### PR DESCRIPTION
## Summary

Adds four **read-only** tools for browsing the Knowledge Base folder tree, so MCP callers can navigate the current folder model instead of only the legacy project-scoped one.

| Tool | Calls | Returns |
|---|---|---|
| `elnora_folders_roots` | `GET /folders/roots` | Top-level folders you can access |
| `elnora_folders_children` | `GET /folders/{id}/children` | Child folders of a folder |
| `elnora_folders_get` | `GET /folders/{id}` | Folder details + breadcrumb path to root |
| `elnora_folders_files` | `GET /folders/{id}/files` | Files placed directly in a folder (paged) |

The existing project-scoped folder tools are unchanged. This is the first slice of bringing the `folders` group up to date with the Knowledge Base; mutation/repoint and sharing follow separately.

## Changes

- `src/tools/folders.ts` — register the four read tools (all `readOnlyHint`)
- `src/tools/scope-guard.ts` — `folders:read` scope for each
- `tests/tools/folders-kb.test.ts` — spy-client regression asserting each tool hits the exact GET path
- `tests/tools/tool-registration.test.ts` — folders group registration coverage

## Testing

- `pnpm build` clean
- `pnpm test` — 133 passing

## Parity note

The paired elnora-cli PR adds the matching commands; its MCP-parity check goes green once this merges.