### PR TITLE
fix(auth): accept an Elnora API key sent as an Authorization: Bearer token

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,10 @@ Create an API key in your [Elnora dashboard](https://platform.elnora.ai) and pas
 }
 ```
 
+If your client only exposes a single bearer/token field, you can instead pass
+the same key as `Authorization: Bearer YOUR_API_KEY` — the server accepts an
+Elnora API key on either header.
+
 **Security best practices:**
 - Never commit API keys to version control
 - Use environment variables or a secrets manager

--- a/src/auth/api-key-header.ts
+++ b/src/auth/api-key-header.ts
@@ -1,0 +1,46 @@
+/**
+ * Resolve an Elnora API key from inbound request headers.
+ *
+ * The MCP endpoint accepts an API key two ways:
+ *   1. `X-API-Key: elnora_live_...`            (the documented header)
+ *   2. `Authorization: Bearer elnora_live_...` (same key in a bearer field)
+ *
+ * (2) exists because many MCP clients only expose a single "token"/bearer field
+ * that maps to `Authorization: Bearer`. Without this, a user pasting their key
+ * there hits the OAuth path and gets a confusing `invalid_token` 401.
+ *
+ * A bearer value WITHOUT the key prefix is a genuine OAuth 2.1 access token and
+ * is intentionally left untouched here so it flows on to the OAuth middleware.
+ * The two can't be confused: OAuth access tokens are `crypto.randomBytes(32)`
+ * base64url strings and never start with the API-key prefix.
+ */
+
+/** Prefix carried by every Elnora API key (`elnora_live_` + 32 chars). */
+export const API_KEY_TOKEN_PREFIX = "elnora_live_";
+
+function firstHeaderValue(value: string | string[] | undefined): string | undefined {
+  return Array.isArray(value) ? value[0] : value;
+}
+
+/**
+ * Returns the Elnora API key present in the request headers, or `undefined`
+ * when there is none (in which case the caller should fall through to OAuth).
+ */
+export function resolveApiKeyFromHeaders(
+  xApiKey: string | string[] | undefined,
+  authorization: string | string[] | undefined,
+): string | undefined {
+  const fromHeader = firstHeaderValue(xApiKey);
+  if (fromHeader) return fromHeader;
+
+  const authz = firstHeaderValue(authorization);
+  if (typeof authz === "string") {
+    const match = /^Bearer\s+(.+)$/i.exec(authz);
+    if (match) {
+      const bearer = match[1].trim();
+      if (bearer.startsWith(API_KEY_TOKEN_PREFIX)) return bearer;
+    }
+  }
+
+  return undefined;
+}

--- a/src/auth/api-key-header.ts
+++ b/src/auth/api-key-header.ts
@@ -33,11 +33,13 @@ export function resolveApiKeyFromHeaders(
   const fromHeader = firstHeaderValue(xApiKey);
   if (fromHeader) return fromHeader;
 
+  // Plain string parsing (no regex) so a crafted Authorization header can't
+  // cause backtracking / ReDoS.
   const authz = firstHeaderValue(authorization);
   if (typeof authz === "string") {
-    const match = /^Bearer\s+(.+)$/i.exec(authz);
-    if (match) {
-      const bearer = match[1].trim();
+    const trimmed = authz.trimStart();
+    if (trimmed.slice(0, 7).toLowerCase() === "bearer ") {
+      const bearer = trimmed.slice(7).trim();
       if (bearer.startsWith(API_KEY_TOKEN_PREFIX)) return bearer;
     }
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,7 @@ import { logAuthEvent } from "./middleware/tool-logging.js";
 import { RedisTokenStore } from "./auth/redis-token-store.js";
 import { RedisClientsStore } from "./auth/redis-clients-store.js";
 import { TokenStore } from "./auth/token-store.js";
+import { resolveApiKeyFromHeaders } from "./auth/api-key-header.js";
 import { validateApiKey } from "./auth/validate-api-key.js";
 import rateLimit from "express-rate-limit";
 
@@ -185,16 +186,18 @@ async function main(): Promise<void> {
 
   /**
    * Middleware 1: API key authentication (runs first).
-   * If X-API-Key header is present, validates against the platform.
-   * If valid, sets auth context and calls next(). If invalid, returns 401.
-   * If no API key header, calls next() to proceed to OAuth middleware.
+   * Accepts an Elnora API key from either `X-API-Key` or an
+   * `Authorization: Bearer elnora_live_...` header (see resolveApiKeyFromHeaders).
+   * If a key is present it is validated against the platform: valid → sets auth
+   * context and calls next(); invalid → 401. A bearer value that is NOT an API
+   * key (a real OAuth token) yields no key here and falls through to OAuth.
    */
   async function apiKeyAuthMiddleware(req: Request, res: Response, next: NextFunction): Promise<void> {
-    const token = req.headers["x-api-key"] as string | undefined;
+    const token = resolveApiKeyFromHeaders(req.headers["x-api-key"], req.headers["authorization"]);
 
     // codeql[js/user-controlled-bypass] Dual auth by design: both API key and OAuth paths
     // validate credentials server-side. API key is validated by the platform's token endpoint;
-    // absence of API key falls through to OAuth bearer token verification in ensureAuthenticated.
+    // absence of an API key falls through to OAuth bearer token verification in ensureAuthenticated.
     if (!token) {
       next();
       return;

--- a/tests/auth/api-key-header.test.ts
+++ b/tests/auth/api-key-header.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from "vitest";
+import { resolveApiKeyFromHeaders, API_KEY_TOKEN_PREFIX } from "../../src/auth/api-key-header.js";
+
+const KEY = `${API_KEY_TOKEN_PREFIX}aaaabbbbccccddddeeeeffffgggghhhh`;
+// A real OAuth access token: crypto.randomBytes(32).toString("base64url") — never has the key prefix.
+const OAUTH_TOKEN = "Zm9vYmFyYmF6cXV4MTIzNDU2Nzg5MGFiY2RlZmdoaWprbG0";
+
+describe("resolveApiKeyFromHeaders", () => {
+  it("returns the key from the X-API-Key header", () => {
+    expect(resolveApiKeyFromHeaders(KEY, undefined)).toBe(KEY);
+  });
+
+  it("returns an API key presented as a bearer token", () => {
+    expect(resolveApiKeyFromHeaders(undefined, `Bearer ${KEY}`)).toBe(KEY);
+  });
+
+  it("accepts a lowercase bearer scheme", () => {
+    expect(resolveApiKeyFromHeaders(undefined, `bearer ${KEY}`)).toBe(KEY);
+  });
+
+  it("ignores a bearer token that is NOT an Elnora key (real OAuth token → OAuth path)", () => {
+    expect(resolveApiKeyFromHeaders(undefined, `Bearer ${OAUTH_TOKEN}`)).toBeUndefined();
+  });
+
+  it("returns undefined when no credential header is present", () => {
+    expect(resolveApiKeyFromHeaders(undefined, undefined)).toBeUndefined();
+  });
+
+  it("prefers X-API-Key over Authorization", () => {
+    const other = `${API_KEY_TOKEN_PREFIX}otherotherotherotherotherother00`;
+    expect(resolveApiKeyFromHeaders(KEY, `Bearer ${other}`)).toBe(KEY);
+  });
+
+  it("handles array-valued headers (takes the first)", () => {
+    expect(resolveApiKeyFromHeaders([KEY, "ignored"], undefined)).toBe(KEY);
+  });
+
+  it("ignores an Authorization header that is not a bearer scheme", () => {
+    expect(resolveApiKeyFromHeaders(undefined, `Basic ${KEY}`)).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Problem

The MCP endpoint accepts an API key **only** via the `X-API-Key` header. Many MCP client connectors expose just a single "token"/bearer field, which they send as `Authorization: Bearer <token>`. When a user pastes their Elnora key there, the server treats it as an OAuth access token, doesn't find it in the token store, and returns:

```
401  { "error": "invalid_token", "error_description": "Invalid access token" }
```

— even though the key is perfectly valid. (This is what the UniteLabs connector hit.)

## Fix

Resolve the API key from **either** header:
- `X-API-Key: elnora_live_…` (unchanged), **or**
- `Authorization: Bearer elnora_live_…` — a bearer value carrying the API-key prefix is routed to the same `validateApiKey` path.

A bearer value **without** the `elnora_live_` prefix is a genuine OAuth 2.1 access token and is left untouched, so it flows on to the OAuth middleware. The two can't be confused: OAuth access tokens are `crypto.randomBytes(32)` base64url strings and never start with the key prefix.

The header logic is extracted into a pure helper (`src/auth/api-key-header.ts`) with unit tests covering every branch. Everything downstream of key resolution — the platform validation call, scopes, error handling — is unchanged, so `X-API-Key` behaves exactly as before. This is purely additive.

## Related

Pairs with an `elnora-plugins` README fix (its "Generic MCP Client" auth section told users to pass the key as a Bearer token — which this makes correct).