### PR TITLE
fix(formatter): empty compact result becomes undefined instead of valid JSON

### DIFF
--- a/src/services/response-formatter.ts
+++ b/src/services/response-formatter.ts
@@ -52,7 +52,13 @@ export function formatToolResult(
     data = stripEmpty(data);
   }
 
-  return JSON.stringify(data);
+  // stripEmpty collapses an empty array/object to `undefined`, and
+  // JSON.stringify(undefined) is `undefined` (not a string) — which would break
+  // the string contract and make a tool emit `text: undefined` (invalid MCP
+  // content). Fall back to the original JSON (e.g. "[]") when compaction stripped
+  // everything away.
+  const formatted = JSON.stringify(data);
+  return formatted ?? jsonString;
 }
 
 /**

--- a/tests/services/response-formatter.test.ts
+++ b/tests/services/response-formatter.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from "vitest";
+import { formatToolResult } from "../../src/services/response-formatter.js";
+
+describe("formatToolResult", () => {
+  it("returns the input unchanged when no options are set", () => {
+    expect(formatToolResult("[]", {})).toBe("[]");
+    expect(formatToolResult('{"a":1}', {})).toBe('{"a":1}');
+  });
+
+  it("returns non-JSON input unchanged", () => {
+    expect(formatToolResult("raw file content", { compact: true })).toBe("raw file content");
+  });
+
+  // Regression: compact on an EMPTY result must stay a valid JSON string.
+  // stripEmpty([]) → undefined and JSON.stringify(undefined) → undefined, which
+  // previously produced `text: undefined` and crashed the tool call with -32602.
+  it("keeps an empty array as '[]' under compact (not undefined)", () => {
+    const out = formatToolResult("[]", { compact: true });
+    expect(out).toBe("[]");
+    expect(typeof out).toBe("string");
+  });
+
+  it("keeps an empty object as '{}' under compact", () => {
+    const out = formatToolResult("{}", { compact: true });
+    expect(out).toBe("{}");
+    expect(typeof out).toBe("string");
+  });
+
+  it("always returns a string even when compaction strips everything", () => {
+    // An object whose only values are empty collapses to undefined via stripEmpty.
+    const out = formatToolResult('{"items":[],"note":""}', { compact: true });
+    expect(typeof out).toBe("string");
+    expect(() => JSON.parse(out)).not.toThrow();
+  });
+
+  it("compacts a non-empty result (strips null/empty fields)", () => {
+    const out = formatToolResult('{"id":"x","note":null,"tags":[]}', { compact: true });
+    expect(JSON.parse(out)).toEqual({ id: "x" });
+  });
+
+  it("applies fields filtering", () => {
+    const out = formatToolResult('[{"id":"1","name":"a","extra":9}]', { fields: "id,name" });
+    expect(JSON.parse(out)).toEqual([{ id: "1", name: "a" }]);
+  });
+});


### PR DESCRIPTION
## Bug

A tool called with `compact: true` whose result is an empty array/object returns invalid MCP content and fails the call:

```
-32602 Invalid tools/call result: content[0].text expected string, received undefined
```

## Cause

For `compact`, `formatToolResult` runs `stripEmpty(data)`, which collapses an empty `[]`/`{}` to `undefined`. `JSON.stringify(undefined)` is `undefined` (not a string), so the function returns `undefined` and the tool emits `text: undefined`.

## Fix

Fall back to the original JSON (e.g. `"[]"`) when compaction strips the whole result away, so the return is always a string. Non-empty compaction is unchanged. Adds regression tests for the formatter.

## Testing
- `pnpm build` clean; `pnpm test` — 178 passing.