### PR TITLE
feat: deprecate the project tools; Knowledge Base folder listing unchanged

### DIFF
--- a/src/services/deprecated.ts
+++ b/src/services/deprecated.ts
@@ -1,0 +1,26 @@
+/**
+ * Deprecation helper for the `elnora_projects_*` tools and the legacy
+ * project-scoped folder paths.
+ *
+ * The Elnora platform removed the "project" concept (ELN-880/881). These tools
+ * stay registered — same names and input schemas, so the CLI↔MCP parity gate
+ * keeps resolving — but they no longer call the retired `/projects` compat shim.
+ * They return a structured no-op notice instead. Scheduled for full removal in a
+ * future major release.
+ */
+export const PROJECTS_REMOVED_MESSAGE =
+  "Projects were removed from the Elnora platform. Use tasks, folders, and the Knowledge Base instead. This tool is a deprecated no-op and will be removed in a future release.";
+
+/** A structured, backend-free deprecation result in MCP tool-result shape. */
+export function projectsRemovedResult(extra?: Record<string, unknown>): {
+  content: { type: "text"; text: string }[];
+} {
+  return {
+    content: [
+      {
+        type: "text" as const,
+        text: JSON.stringify({ deprecated: true, message: PROJECTS_REMOVED_MESSAGE, ...extra }),
+      },
+    ],
+  };
+}

--- a/src/tools/folders.ts
+++ b/src/tools/folders.ts
@@ -5,6 +5,7 @@ import { RequestContext } from "../server.js";
 import { handleApiError } from "../services/error-handler.js";
 import { withGuard } from "./with-guard.js";
 import { OUTPUT_OPTIONS_SCHEMA } from "../services/response-formatter.js";
+import { projectsRemovedResult } from "../services/deprecated.js";
 
 export function registerFolderTools(
   server: McpServer,
@@ -103,7 +104,7 @@ export function registerFolderTools(
     "elnora_folders_list",
     {
       title: "elnora_folders_list",
-      description: "List folders in a project",
+      description: "[DEPRECATED] List folders in a project — projects were removed. Use `folders roots` and `folders children` to browse the Knowledge Base.",
       inputSchema: {
         projectId: z.string().uuid().describe("Project UUID"),
 
@@ -111,13 +112,12 @@ export function registerFolderTools(
       },
       annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: true },
     },
-    withGuard("elnora_folders_list", getContext, async ({ projectId }) => {
-      try {
-        const result = await getClient().get(`/projects/${projectId}/folders`);
-        return { content: [{ type: "text" as const, text: JSON.stringify(result) }] };
-      } catch (error) {
-        return { content: [{ type: "text" as const, text: handleApiError(error) }], isError: true };
-      }
+    withGuard("elnora_folders_list", getContext, async () => {
+      // No-op: the legacy /projects/{id}/folders route is retired. Browse the KB
+      // via elnora_folders_roots + elnora_folders_children.
+      return projectsRemovedResult({
+        hint: "Use elnora_folders_roots and elnora_folders_children to browse Knowledge Base folders.",
+      });
     }),
   );
 
@@ -125,24 +125,28 @@ export function registerFolderTools(
     "elnora_folders_create",
     {
       title: "elnora_folders_create",
-      description: "Create a Knowledge Base folder (or a legacy project folder when project is set)",
+      description: "Create a Knowledge Base folder. (The legacy project-scoped path via `project` is deprecated and no longer supported.)",
       inputSchema: {
         name: z.string().min(1).max(255).describe("Folder name"),
         parentId: z.string().uuid().optional().describe("Parent folder UUID for nesting"),
-        project: z.string().uuid().optional().describe("Legacy: create a project-scoped folder instead of a Knowledge Base folder"),
+        project: z.string().uuid().optional().describe("[DEPRECATED] Legacy project-scoped folders were removed; this option is a no-op."),
 
         ...OUTPUT_OPTIONS_SCHEMA,
       },
       annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: true },
     },
     withGuard("elnora_folders_create", getContext, async ({ name, parentId, project }) => {
+      if (project) {
+        // Legacy project-scoped folders were removed (ELN-880/881). No-op instead
+        // of calling the retired /projects/{id}/folders route.
+        return projectsRemovedResult({
+          hint: "Project-scoped folders were removed. Omit `project` to create a Knowledge Base folder.",
+        });
+      }
       try {
-        // Both the KB and legacy create bodies use `parentFolderId`.
         const body: Record<string, unknown> = { name };
         if (parentId) body.parentFolderId = parentId;
-        const result = project
-          ? await getClient().post(`/projects/${project}/folders`, body)
-          : await getClient().post(`/folders`, body);
+        const result = await getClient().post(`/folders`, body);
         return { content: [{ type: "text" as const, text: JSON.stringify(result) }] };
       } catch (error) {
         return { content: [{ type: "text" as const, text: handleApiError(error) }], isError: true };

--- a/src/tools/projects.ts
+++ b/src/tools/projects.ts
@@ -2,20 +2,27 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { ElnoraApiClient } from "../services/elnora-api-client.js";
 import { RequestContext } from "../server.js";
-import { handleApiError } from "../services/error-handler.js";
 import { withGuard } from "./with-guard.js";
 import { OUTPUT_OPTIONS_SCHEMA } from "../services/response-formatter.js";
+import { projectsRemovedResult } from "../services/deprecated.js";
 
+/**
+ * The `elnora_projects_*` tools are deprecated no-ops (ELN-880/881 removed the
+ * platform "project" concept). They stay registered with unchanged names and
+ * input schemas — so the CLI↔MCP parity gate and any existing MCP clients keep
+ * resolving — but no longer call the retired `/projects` compat shim. Each
+ * returns a structured deprecation notice. `getClient` is intentionally unused.
+ */
 export function registerProjectTools(
   server: McpServer,
-  getClient: () => ElnoraApiClient,
+  _getClient: () => ElnoraApiClient,
   getContext: () => RequestContext,
 ): void {
   server.registerTool(
     "elnora_projects_list",
     {
       title: "elnora_projects_list",
-      description: "List all projects accessible to the current user",
+      description: "[DEPRECATED] List all projects accessible to the current user — projects were removed; this is a no-op.",
       inputSchema: {
         page: z.number().int().min(1).default(1).describe("Page number"),
         pageSize: z.number().int().min(1).max(100).default(25).describe("Results per page"),
@@ -24,21 +31,14 @@ export function registerProjectTools(
       },
       annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: true },
     },
-    withGuard("elnora_projects_list", getContext, async ({ page, pageSize }) => {
-      try {
-        const result = await getClient().get("/projects", { page, pageSize });
-        return { content: [{ type: "text" as const, text: JSON.stringify(result) }] };
-      } catch (error) {
-        return { content: [{ type: "text" as const, text: handleApiError(error) }], isError: true };
-      }
-    }),
+    withGuard("elnora_projects_list", getContext, async () => projectsRemovedResult({ items: [], totalCount: 0 })),
   );
 
   server.registerTool(
     "elnora_projects_get",
     {
       title: "elnora_projects_get",
-      description: "Get details of a specific project",
+      description: "[DEPRECATED] Get details of a specific project — projects were removed; this is a no-op.",
       inputSchema: {
         projectId: z.string().uuid().describe("Project UUID"),
 
@@ -46,21 +46,14 @@ export function registerProjectTools(
       },
       annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: true },
     },
-    withGuard("elnora_projects_get", getContext, async ({ projectId }) => {
-      try {
-        const result = await getClient().get(`/projects/${projectId}`);
-        return { content: [{ type: "text" as const, text: JSON.stringify(result) }] };
-      } catch (error) {
-        return { content: [{ type: "text" as const, text: handleApiError(error) }], isError: true };
-      }
-    }),
+    withGuard("elnora_projects_get", getContext, async () => projectsRemovedResult()),
   );
 
   server.registerTool(
     "elnora_projects_create",
     {
       title: "elnora_projects_create",
-      description: "Create a new project",
+      description: "[DEPRECATED] Create a new project — projects were removed; this is a no-op.",
       inputSchema: {
         name: z.string().min(1).max(200).describe("Project name"),
         description: z.string().max(2000).optional().describe("Project description"),
@@ -70,21 +63,14 @@ export function registerProjectTools(
       },
       annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: true },
     },
-    withGuard("elnora_projects_create", getContext, async ({ name, description, icon }) => {
-      try {
-        const result = await getClient().post("/projects", { name, description, icon });
-        return { content: [{ type: "text" as const, text: JSON.stringify(result) }] };
-      } catch (error) {
-        return { content: [{ type: "text" as const, text: handleApiError(error) }], isError: true };
-      }
-    }),
+    withGuard("elnora_projects_create", getContext, async () => projectsRemovedResult()),
   );
 
   server.registerTool(
     "elnora_projects_update",
     {
       title: "elnora_projects_update",
-      description: "Update an existing project",
+      description: "[DEPRECATED] Update an existing project — projects were removed; this is a no-op.",
       inputSchema: {
         projectId: z.string().uuid().describe("Project UUID"),
         name: z.string().min(1).max(200).optional().describe("New name"),
@@ -95,28 +81,14 @@ export function registerProjectTools(
       },
       annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: true, openWorldHint: true },
     },
-    withGuard("elnora_projects_update", getContext, async ({ projectId, name, description, icon }) => {
-      try {
-        const body: Record<string, string> = {};
-        if (name !== undefined) body.name = name;
-        if (description !== undefined) body.description = description;
-        if (icon !== undefined) body.icon = icon;
-        if (Object.keys(body).length === 0) {
-          return { content: [{ type: "text" as const, text: "Error: At least one field (name, description, or icon) must be provided." }], isError: true };
-        }
-        const result = await getClient().put(`/projects/${projectId}`, body);
-        return { content: [{ type: "text" as const, text: JSON.stringify(result) }] };
-      } catch (error) {
-        return { content: [{ type: "text" as const, text: handleApiError(error) }], isError: true };
-      }
-    }),
+    withGuard("elnora_projects_update", getContext, async () => projectsRemovedResult()),
   );
 
   server.registerTool(
     "elnora_projects_archive",
     {
       title: "elnora_projects_archive",
-      description: "Archive (delete) a project",
+      description: "[DEPRECATED] Archive (delete) a project — projects were removed; this is a no-op.",
       inputSchema: {
         projectId: z.string().uuid().describe("Project UUID"),
 
@@ -124,21 +96,14 @@ export function registerProjectTools(
       },
       annotations: { readOnlyHint: false, destructiveHint: true, idempotentHint: true, openWorldHint: true },
     },
-    withGuard("elnora_projects_archive", getContext, async ({ projectId }) => {
-      try {
-        await getClient().del(`/projects/${projectId}`);
-        return { content: [{ type: "text" as const, text: JSON.stringify({ archived: true, projectId }) }] };
-      } catch (error) {
-        return { content: [{ type: "text" as const, text: handleApiError(error) }], isError: true };
-      }
-    }),
+    withGuard("elnora_projects_archive", getContext, async () => projectsRemovedResult()),
   );
 
   server.registerTool(
     "elnora_projects_members",
     {
       title: "elnora_projects_members",
-      description: "List members of a project",
+      description: "[DEPRECATED] List members of a project — projects were removed; this is a no-op.",
       inputSchema: {
         projectId: z.string().uuid().describe("Project UUID"),
 
@@ -146,21 +111,14 @@ export function registerProjectTools(
       },
       annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: true },
     },
-    withGuard("elnora_projects_members", getContext, async ({ projectId }) => {
-      try {
-        const result = await getClient().get(`/projects/${projectId}/members`);
-        return { content: [{ type: "text" as const, text: JSON.stringify(result) }] };
-      } catch (error) {
-        return { content: [{ type: "text" as const, text: handleApiError(error) }], isError: true };
-      }
-    }),
+    withGuard("elnora_projects_members", getContext, async () => projectsRemovedResult()),
   );
 
   server.registerTool(
     "elnora_projects_addMember",
     {
       title: "elnora_projects_addMember",
-      description: "Add a member to a project",
+      description: "[DEPRECATED] Add a member to a project — projects were removed; this is a no-op.",
       inputSchema: {
         projectId: z.string().uuid().describe("Project UUID"),
         userId: z.string().min(1).max(255).describe("User ID to add"),
@@ -170,21 +128,14 @@ export function registerProjectTools(
       },
       annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: true },
     },
-    withGuard("elnora_projects_addMember", getContext, async ({ projectId, userId, role }) => {
-      try {
-        const result = await getClient().post(`/projects/${projectId}/members`, { userId, role });
-        return { content: [{ type: "text" as const, text: JSON.stringify(result) }] };
-      } catch (error) {
-        return { content: [{ type: "text" as const, text: handleApiError(error) }], isError: true };
-      }
-    }),
+    withGuard("elnora_projects_addMember", getContext, async () => projectsRemovedResult()),
   );
 
   server.registerTool(
     "elnora_projects_updateRole",
     {
       title: "elnora_projects_updateRole",
-      description: "Update a project member's role",
+      description: "[DEPRECATED] Update a project member's role — projects were removed; this is a no-op.",
       inputSchema: {
         projectId: z.string().uuid().describe("Project UUID"),
         userId: z.string().min(1).max(255).describe("User ID"),
@@ -194,21 +145,14 @@ export function registerProjectTools(
       },
       annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: true, openWorldHint: true },
     },
-    withGuard("elnora_projects_updateRole", getContext, async ({ projectId, userId, role }) => {
-      try {
-        const result = await getClient().put(`/projects/${projectId}/members/${userId}/role`, { role });
-        return { content: [{ type: "text" as const, text: JSON.stringify(result) }] };
-      } catch (error) {
-        return { content: [{ type: "text" as const, text: handleApiError(error) }], isError: true };
-      }
-    }),
+    withGuard("elnora_projects_updateRole", getContext, async () => projectsRemovedResult()),
   );
 
   server.registerTool(
     "elnora_projects_removeMember",
     {
       title: "elnora_projects_removeMember",
-      description: "Remove a member from a project",
+      description: "[DEPRECATED] Remove a member from a project — projects were removed; this is a no-op.",
       inputSchema: {
         projectId: z.string().uuid().describe("Project UUID"),
         userId: z.string().min(1).max(255).describe("User ID to remove"),
@@ -217,21 +161,14 @@ export function registerProjectTools(
       },
       annotations: { readOnlyHint: false, destructiveHint: true, idempotentHint: true, openWorldHint: true },
     },
-    withGuard("elnora_projects_removeMember", getContext, async ({ projectId, userId }) => {
-      try {
-        await getClient().del(`/projects/${projectId}/members/${userId}`);
-        return { content: [{ type: "text" as const, text: JSON.stringify({ removed: true, userId }) }] };
-      } catch (error) {
-        return { content: [{ type: "text" as const, text: handleApiError(error) }], isError: true };
-      }
-    }),
+    withGuard("elnora_projects_removeMember", getContext, async () => projectsRemovedResult()),
   );
 
   server.registerTool(
     "elnora_projects_leave",
     {
       title: "elnora_projects_leave",
-      description: "Leave a project",
+      description: "[DEPRECATED] Leave a project — projects were removed; this is a no-op.",
       inputSchema: {
         projectId: z.string().uuid().describe("Project UUID"),
 
@@ -239,13 +176,6 @@ export function registerProjectTools(
       },
       annotations: { readOnlyHint: false, destructiveHint: true, idempotentHint: true, openWorldHint: true },
     },
-    withGuard("elnora_projects_leave", getContext, async ({ projectId }) => {
-      try {
-        await getClient().post(`/projects/${projectId}/leave`);
-        return { content: [{ type: "text" as const, text: JSON.stringify({ left: true, projectId }) }] };
-      } catch (error) {
-        return { content: [{ type: "text" as const, text: handleApiError(error) }], isError: true };
-      }
-    }),
+    withGuard("elnora_projects_leave", getContext, async () => projectsRemovedResult()),
   );
 }

--- a/tests/tools/folders-mutation.test.ts
+++ b/tests/tools/folders-mutation.test.ts
@@ -39,10 +39,11 @@ describe("elnora_folders_create", () => {
     expect(client.post).toHaveBeenCalledWith(`/folders`, { name: "Sub", parentFolderId: PARENT_ID });
   });
 
-  it("uses the legacy project endpoint when project is set", async () => {
+  it("no-ops the legacy project path (projects removed; no backend call)", async () => {
     const { client, invoke } = makeServerWithSpyClient();
-    await invoke("elnora_folders_create", { name: "Leg", project: PROJECT_ID });
-    expect(client.post).toHaveBeenCalledWith(`/projects/${PROJECT_ID}/folders`, { name: "Leg" });
+    const result = await invoke("elnora_folders_create", { name: "Leg", project: PROJECT_ID });
+    expect(client.post).not.toHaveBeenCalled();
+    expect(JSON.stringify(result)).toContain("deprecated");
   });
 });
 

--- a/tests/tools/projects-deprecated.test.ts
+++ b/tests/tools/projects-deprecated.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, vi } from "vitest";
+import { createElnoraServer, RequestContext } from "../../src/server.js";
+import { ALL_SCOPES } from "../../src/constants.js";
+import type { ElnoraApiClient } from "../../src/services/elnora-api-client.js";
+
+// ELN-880/881 removed the platform "project" concept. The elnora_projects_* tools
+// and the legacy elnora_folders_list stay registered (CLI↔MCP parity + back-compat)
+// but are deprecated no-ops: they must NOT call the retired /projects compat shim.
+
+function makeServerWithSpyClient() {
+  const client = {
+    get: vi.fn().mockResolvedValue({}),
+    post: vi.fn().mockResolvedValue({}),
+    put: vi.fn().mockResolvedValue({}),
+    patch: vi.fn().mockResolvedValue({}),
+    del: vi.fn().mockResolvedValue({}),
+  } as unknown as ElnoraApiClient;
+  const ctx: RequestContext = { client, clientId: "test", scopes: ALL_SCOPES };
+  const server = createElnoraServer(() => ctx);
+  const tools = (
+    server as unknown as {
+      _registeredTools: Record<string, { handler: (args: unknown, extra: unknown) => Promise<unknown> }>;
+    }
+  )._registeredTools;
+  const invoke = (name: string, args: Record<string, unknown>) => tools[name].handler(args, {});
+  return { client, invoke };
+}
+
+const PROJECT_ID = "a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d";
+const USER_ID = "d5c4b3a2-f6e5-4b7a-9d8c-1f0e2a3b4c5d";
+
+const DEPRECATED_TOOL_CALLS: Array<[string, Record<string, unknown>]> = [
+  ["elnora_projects_list", {}],
+  ["elnora_projects_get", { projectId: PROJECT_ID }],
+  ["elnora_projects_create", { name: "X" }],
+  ["elnora_projects_update", { projectId: PROJECT_ID, name: "Y" }],
+  ["elnora_projects_archive", { projectId: PROJECT_ID }],
+  ["elnora_projects_members", { projectId: PROJECT_ID }],
+  ["elnora_projects_addMember", { projectId: PROJECT_ID, userId: USER_ID }],
+  ["elnora_projects_updateRole", { projectId: PROJECT_ID, userId: USER_ID, role: "Admin" }],
+  ["elnora_projects_removeMember", { projectId: PROJECT_ID, userId: USER_ID }],
+  ["elnora_projects_leave", { projectId: PROJECT_ID }],
+  ["elnora_folders_list", { projectId: PROJECT_ID }],
+];
+
+describe("deprecated project tools are no-ops", () => {
+  for (const [name, args] of DEPRECATED_TOOL_CALLS) {
+    it(`${name} returns a deprecation notice without calling the backend`, async () => {
+      const { client, invoke } = makeServerWithSpyClient();
+      const result = await invoke(name, args);
+      expect(client.get).not.toHaveBeenCalled();
+      expect(client.post).not.toHaveBeenCalled();
+      expect(client.put).not.toHaveBeenCalled();
+      expect(client.patch).not.toHaveBeenCalled();
+      expect(client.del).not.toHaveBeenCalled();
+      expect(JSON.stringify(result)).toContain("deprecated");
+    });
+  }
+});


### PR DESCRIPTION
## Summary

Companion to the elnora-cli change — the `projects` concept is being retired. Deprecated **in place**, no breaking changes, minor release.

- The `elnora_projects_*` tools and the legacy project-scoped folder listing stay registered (same names and input schemas, so CLI/MCP tool parity holds) but are now **no-ops** that return a short deprecation notice instead of calling the removed endpoints.
- `elnora_folders_create` no longer accepts the legacy project path; Knowledge Base folder creation is unchanged.

## Testing

- `npm run build`, test typecheck, `npm test` — 189 passing (incl. new no-op coverage)
